### PR TITLE
add coverage binary build

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,32 +1,22 @@
 FROM openshift/origin-release:golang-1.13 as builder
 
-ARG REMOTE_SOURCE
-ARG REMOTE_SOURCE_DIR
-ARG GITHUB_TOKEN
-ARG COMPONENT_VERSION
+ENV REMOTE_SOURCE='.'
+ENV REMOTE_SOURCE_DIR='/remote-source'
 
 ENV USE_VENDORIZED_BUILD_HARNESS=true
 ENV COMPONENT_NAME=rcm-controller
 ENV COMPONENT_VERSION="${COMPONENT_VERSION}"
 ENV COMPONENT_TAG_EXTENSION=" "
-#RUN yum install -y tar gzip make which
 
 COPY $REMOTE_SOURCE $REMOTE_SOURCE_DIR/app/
 WORKDIR $REMOTE_SOURCE_DIR/app
 RUN git config --global url."https://${GITHUB_TOKEN}:x-oauth-basic@github.com/".insteadOf "https://github.com/"
 RUN GOFLAGS="" go build ./cmd/manager
-RUN GOFLAGS="" go test -covermode=atomic -coverpkg=github.com/open-cluster-management/managedcluster-import-controller/pkg/... -c -tags testrunmain ./cmd/manager -o manager-coverage
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 RUN microdnf update
 
-ARG VCS_REF
-ARG VCS_URL
-ARG IMAGE_NAME
-ARG IMAGE_DESCRIPTION
-ARG ARCH_TYPE
-ARG REMOTE_SOURCE_DIR
-ARG BUILD_HARNESS_EXTENSIONS_PROJECT
+ENV REMOTE_SOURCE_DIR='/remote-source'
 
 ENV OPERATOR=/usr/local/bin/rcm-controller \
     USER_UID=1001 \
@@ -35,10 +25,6 @@ ENV OPERATOR=/usr/local/bin/rcm-controller \
 
 # install operator binary
 COPY --from=builder $REMOTE_SOURCE_DIR/app/manager ${OPERATOR}
-COPY --from=builder $REMOTE_SOURCE_DIR/app/manager-coverage ${OPERATOR}-coverage
-COPY --from=builder \
-    $REMOTE_SOURCE_DIR/app/$BUILD_HARNESS_EXTENSIONS_PROJECT/modules/component/bin/component/coverage-entrypoint-func.sh \
-    /usr/local/bin/coverage-entrypoint-func.sh
 COPY --from=builder $REMOTE_SOURCE_DIR/app/build/bin /usr/local/bin
 COPY --from=builder $REMOTE_SOURCE_DIR/app/build/resources /usr/local/resources
 RUN  /usr/local/bin/user_setup
@@ -46,14 +32,3 @@ RUN  /usr/local/bin/user_setup
 ENTRYPOINT ["/usr/local/bin/entrypoint"]
 
 USER ${USER_UID}
-
-LABEL com.redhat.component="rcm-controller-container" \
-      name="rhacm1-tech-preview/rcm-controller-rhel8" \
-      version="${CI_CONTAINER_VERSION}" \
-      release="${CI_CONTAINER_RELEASE}" \
-      summary="rcm-controller" \
-      io.openshift.expose-services="" \
-      io.openshift.tags="data,images" \
-      io.k8s.display-name="rcm-controller" \
-      maintainer="['eisraeli@redhat.com', 'jbieren@redhat.com']" \
-      description="rcm-controller"

--- a/build/Dockerfile.prow
+++ b/build/Dockerfile.prow
@@ -19,6 +19,7 @@ ENV OPERATOR=/usr/local/bin/rcm-controller \
 
 # install operator binary
 COPY --from=builder $REMOTE_SOURCE_DIR/app/manager ${OPERATOR}
+COPY --from=builder $REMOTE_SOURCE_DIR/app/manager-coverage ${OPERATOR}-coverage
 COPY --from=builder $REMOTE_SOURCE_DIR/app/build/bin /usr/local/bin
 COPY --from=builder $REMOTE_SOURCE_DIR/app/build/resources /usr/local/resources
 


### PR DESCRIPTION
trying to add coverage without build-harness, my thought is to locally save one copy of the entrypoint file? 

Also added one `make` command to download if coverage entrypoint is updated

/cc @itdove 
