### PR TITLE
[release-2.4] avoid to add finalizer to manifestworks if the cluster is deleting

### DIFF
--- a/pkg/controller/manifestwork/manifestwork_controller.go
+++ b/pkg/controller/manifestwork/manifestwork_controller.go
@@ -132,6 +132,11 @@ func (r *ReconcileManifestWork) assertManifestWorkFinalizer(ctx context.Context,
 		return nil
 	}
 
+	if !cluster.DeletionTimestamp.IsZero() {
+		// cluser is deleting, do nothing
+		return nil
+	}
+
 	// there are manifest works in the managed cluster namespace, make sure the managed cluster has the manifest work finalizer
 	patch := client.MergeFrom(cluster.DeepCopy())
 	modified := resourcemerge.BoolPtr(false)


### PR DESCRIPTION
Signed-off-by: Wei Liu <liuweixa@redhat.com>