### PR TITLE
fix ci lint

### DIFF
--- a/build/golangci.yml
+++ b/build/golangci.yml
@@ -24,11 +24,6 @@ run:
     - ".*\\.pb\\.go"
     - ".*\\.gen\\.go"
     - ".*_test\\.go"
-issues:
-  # We want to make sure we get a full report every time. Setting these
-  # to zero disables the limit.
-  max-issues-per-linter: 0
-  max-same-issues: 0
 
 linters:
   # please, do not use `enable-all`: it's deprecated and will be removed soon.
@@ -196,6 +191,10 @@ linters-settings:
       # - wrapperFunc
 
 issues:
+  # We want to make sure we get a full report every time. Setting these
+  # to zero disables the limit.
+  max-issues-per-linter: 0
+
   # List of regexps of issue texts to exclude, empty list by default.
   # But independently from this option we use default exclude patterns,
   # it can be disabled by `exclude-use-default: false`. To list all


### PR DESCRIPTION
Signed-off-by: zhujian <jiazhu@redhat.com>

fix lint:
```
╰─# make lint                                                                                                                      1 ↵
build/run-lint-check.sh
Running linting tool ...
ERRO Can't read config: can't read viper config: While parsing config: yaml: unmarshal errors:
  line 198: mapping key "issues" already defined at line 27
make: *** [lint] Error 3
```