### PR TITLE
Revert "fix PodSecurity warning"

### DIFF
--- a/pkg/controller/importconfig/manifests/klusterlet/operator.yaml
+++ b/pkg/controller/importconfig/manifests/klusterlet/operator.yaml
@@ -17,10 +17,6 @@ spec:
       labels:
         app: klusterlet
     spec:
-      securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
       serviceAccountName: klusterlet
 {{- if .NodeSelector }}
       nodeSelector:
@@ -48,12 +44,6 @@ spec:
           - "/registration-operator"
           - "klusterlet"
           - "--disable-leader-election"
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-              - ALL
-          privileged: false
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
Reverts stolostron/managedcluster-import-controller#276

``` yaml
        seccompProfile:
          type: RuntimeDefault
```

is not support by 4.10 and before. Do we need to revert it?