### PR TITLE
Fix: remove seccomputeProfile to support ocp 4.10.

### DIFF
--- a/pkg/controller/importconfig/manifests/klusterlet/operator.yaml
+++ b/pkg/controller/importconfig/manifests/klusterlet/operator.yaml
@@ -19,8 +19,6 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
       serviceAccountName: klusterlet
 {{- if .NodeSelector }}
       nodeSelector:


### PR DESCRIPTION
From this doc: https://github.com/redhat-openshift-ecosystem/community-operators-prod/discussions/1417

OCP 4.10 doesn't support `seccomputeProfile`, remove it.