### PR TITLE
preserve created-via hypershift annotation

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -43,6 +43,7 @@ const (
 	CreatedViaAI         = "assisted-installer"
 	CreatedViaHive       = "hive"
 	CreatedViaDiscovery  = "discovery"
+	CreatedViaHypershift = "hypershift"
 )
 
 /* #nosec */

--- a/pkg/controller/managedcluster/managedcluster_controller.go
+++ b/pkg/controller/managedcluster/managedcluster_controller.go
@@ -194,11 +194,12 @@ func ensureCreateViaAnnotation(modified *bool, cluster *clusterv1.ManagedCluster
 		return
 	}
 
-	// there is a created-via annotation and the annotation is not created by hive, we ensue that the
+	// there is a created-via annotation and the annotation is not created by hive or hypershift, we ensue that the
 	// created-via annotation is default annotation
 	if viaAnnotation != constants.CreatedViaAI &&
 		viaAnnotation != constants.CreatedViaHive &&
-		viaAnnotation != constants.CreatedViaDiscovery {
+		viaAnnotation != constants.CreatedViaDiscovery &&
+		viaAnnotation != constants.CreatedViaHypershift {
 		resourcemerge.MergeMap(modified, &cluster.Annotations, createViaOtherAnnotation)
 	}
 }


### PR DESCRIPTION
This is part of https://issues.redhat.com/browse/ACM-6547 to preserve `open-cluster-management/created-via: hypershift` annotation which is set by the hypershift hosted cluster auto-import controller.