### PR TITLE
Create Empty Image Pull Secret when no default image pull secret specified.

### DIFF
--- a/pkg/bootstrap/render.go
+++ b/pkg/bootstrap/render.go
@@ -236,9 +236,10 @@ func (b *KlusterletManifestsConfig) Generate(ctx context.Context, clientHolder *
 			return nil, err
 		}
 
-		if imagePullSecret != nil {
-			files = append(files, "manifests/klusterlet/image_pull_secret.yaml")
+		if imagePullSecret == nil {
+			return nil, fmt.Errorf("imagePullSecret is nil")
 		}
+		files = append(files, "manifests/klusterlet/image_pull_secret.yaml")
 
 		imagePullSecretConfig, err := getImagePullSecretConfig(imagePullSecret)
 		if err != nil {


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/ACM-9759