### PR TITLE
🐛 Add default preemptionPolicy for priority class

### DIFF
--- a/pkg/bootstrap/manifests/klusterlet/priority_class.yaml
+++ b/pkg/bootstrap/manifests/klusterlet/priority_class.yaml
@@ -5,3 +5,4 @@ metadata:
 value: 1000000
 globalDefault: false
 description: "This priority class should be used for klusterlet agents only."
+preemptionPolicy: PreemptLowerPriority


### PR DESCRIPTION
Add default `preemptionPolicy` value `PreemptLowerPriority` for the priority class, otherwise every time applying this resource, it is regarded as changed since the existing preemptionPolicy is PreemptLowerPriority, but the required preemptionPolicy is nil. see [here](https://github.com/stolostron/managedcluster-import-controller/blob/4ae27f63d570ccb49d8f53fb22420078577cb6c9/pkg/helpers/helpers.go#L619), and this will result in the cluster condition changing back and forth(ManagedClusterImporting & ManagedClusterImported).
```
equality.Semantic.DeepEqual(existing.PreemptionPolicy, required.PreemptionPolicy) 
```