### PR TITLE
Add "global" KlusterletConfig Support.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/openshift/hive/apis v0.0.0-20230825202726-4418e43e27a3
 	github.com/openshift/library-go v0.0.0-20230809121909-d7e7beca5bae // https://github.com/openshift/library-go/tree/release-4.14
 	github.com/spf13/pflag v1.0.5
-	github.com/stolostron/cluster-lifecycle-api v0.0.0-20240130112703-747158a63f05
+	github.com/stolostron/cluster-lifecycle-api v0.0.0-20240422015315-a15e3cb9cd80
 	go.uber.org/zap v1.26.0
 	golang.org/x/text v0.13.0
 	k8s.io/api v0.28.2

--- a/go.sum
+++ b/go.sum
@@ -386,8 +386,8 @@ github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnIn
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
-github.com/stolostron/cluster-lifecycle-api v0.0.0-20240130112703-747158a63f05 h1:6BHHHhtkG7dIvwF3zSWybvighvG4D4Eis0NSSBqey1E=
-github.com/stolostron/cluster-lifecycle-api v0.0.0-20240130112703-747158a63f05/go.mod h1:ZNQ3Rttgk4HEreCHfocrhXavLDaUgHbZaUqk5dP8/As=
+github.com/stolostron/cluster-lifecycle-api v0.0.0-20240422015315-a15e3cb9cd80 h1:ZmDhQ0gX+Oq5RyqvzIm4ia87Q1D7bohKIOHQST8KNIU=
+github.com/stolostron/cluster-lifecycle-api v0.0.0-20240422015315-a15e3cb9cd80/go.mod h1:ZNQ3Rttgk4HEreCHfocrhXavLDaUgHbZaUqk5dP8/As=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -140,3 +140,7 @@ const (
 const (
 	DefaultKlusterletPriorityClassName = "klusterlet-critical"
 )
+
+const (
+	GlobalKlusterletConfigName = "global"
+)

--- a/pkg/controller/importconfig/klusterletconfighandler.go
+++ b/pkg/controller/importconfig/klusterletconfighandler.go
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	apiconstants "github.com/stolostron/cluster-lifecycle-api/constants"
+	"github.com/stolostron/managedcluster-import-controller/pkg/constants"
 )
 
 var _ handler.EventHandler = &enqueueManagedClusterInKlusterletConfigAnnotation{}
@@ -61,9 +62,10 @@ func IndexManagedClusterByKlusterletconfigAnnotation(obj interface{}) ([]string,
 	if !ok {
 		return nil, fmt.Errorf("not a managedcluster object")
 	}
+	klusterletconfigs := []string{constants.GlobalKlusterletConfigName}
 	klusterletconfig, ok := managedCluster.GetAnnotations()[apiconstants.AnnotationKlusterletConfig]
 	if ok && klusterletconfig != "" {
-		return []string{klusterletconfig}, nil
+		klusterletconfigs = append(klusterletconfigs, klusterletconfig)
 	}
-	return nil, nil
+	return klusterletconfigs, nil
 }

--- a/pkg/helpers/klusterletconfig.go
+++ b/pkg/helpers/klusterletconfig.go
@@ -1,0 +1,32 @@
+package helpers
+
+import (
+	"fmt"
+
+	listerklusterletconfigv1alpha1 "github.com/stolostron/cluster-lifecycle-api/client/klusterletconfig/listers/klusterletconfig/v1alpha1"
+	klusterletconfighelper "github.com/stolostron/cluster-lifecycle-api/helpers/klusterletconfig"
+	klusterletconfigv1alpha1 "github.com/stolostron/cluster-lifecycle-api/klusterletconfig/v1alpha1"
+	"github.com/stolostron/managedcluster-import-controller/pkg/constants"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+func GetMergedKlusterletConfigWithGlobal(
+	klusterletconfigName string,
+	kcLister listerklusterletconfigv1alpha1.KlusterletConfigLister,
+) (*klusterletconfigv1alpha1.KlusterletConfig, error) {
+	var err error
+	var kc *klusterletconfigv1alpha1.KlusterletConfig
+	if klusterletconfigName != "" {
+		kc, err = kcLister.Get(klusterletconfigName)
+		if err != nil && !apierrors.IsNotFound(err) {
+			return nil, fmt.Errorf("failed to get klusterletconfig %s: %v", klusterletconfigName, err)
+		}
+	}
+
+	globalKlusterletConfig, err := kcLister.Get(constants.GlobalKlusterletConfigName)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return nil, fmt.Errorf("failed to get global klusterletconfig: %v", err)
+	}
+
+	return klusterletconfighelper.MergeKlusterletConfigs(globalKlusterletConfig, kc)
+}

--- a/pkg/helpers/klusterletconfig_test.go
+++ b/pkg/helpers/klusterletconfig_test.go
@@ -1,0 +1,93 @@
+package helpers
+
+import (
+	"testing"
+
+	klusterletconfigv1alpha1 "github.com/stolostron/cluster-lifecycle-api/klusterletconfig/v1alpha1"
+	"github.com/stolostron/managedcluster-import-controller/pkg/constants"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	labels "k8s.io/apimachinery/pkg/labels"
+)
+
+func TestGetMergedKlusterletConfigWithGlobal(t *testing.T) {
+	tests := []struct {
+		name                 string
+		klusterletconfigName string
+		getFunc              func(string) (*klusterletconfigv1alpha1.KlusterletConfig, error)
+		wantErr              bool
+	}{
+		{
+			name:                 "return error when klusterletconfigLister.Get returns an error",
+			klusterletconfigName: "test",
+			getFunc: func(string) (*klusterletconfigv1alpha1.KlusterletConfig, error) {
+				return nil, errors.NewServiceUnavailable("unavailable")
+			},
+			wantErr: true,
+		},
+		{
+			name:                 "return error when klusterletconfigLister.Get for global klusterletconfig returns an error",
+			klusterletconfigName: "",
+			getFunc: func(name string) (*klusterletconfigv1alpha1.KlusterletConfig, error) {
+				if name == constants.GlobalKlusterletConfigName {
+					return nil, errors.NewServiceUnavailable("unavailable")
+				}
+				return &klusterletconfigv1alpha1.KlusterletConfig{}, nil
+			},
+			wantErr: true,
+		},
+		{
+			name:                 "return merged klusterletconfig when klusterletconfigLister.Get functions succeed",
+			klusterletconfigName: "test",
+			getFunc: func(name string) (*klusterletconfigv1alpha1.KlusterletConfig, error) {
+				return &klusterletconfigv1alpha1.KlusterletConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: name,
+					},
+				}, nil
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lister := &mockKlusterletConfigLister{
+				GetFunc: tt.getFunc,
+			}
+
+			_, err := GetMergedKlusterletConfigWithGlobal(tt.klusterletconfigName, lister)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("expected nil error, got %v", err)
+				}
+			}
+		})
+	}
+}
+
+// mockKlusterletConfigLister is a mock implementation of KlusterletConfigLister interface.
+type mockKlusterletConfigLister struct {
+	ListFunc func(selector labels.Selector) ([]*klusterletconfigv1alpha1.KlusterletConfig, error)
+	GetFunc  func(name string) (*klusterletconfigv1alpha1.KlusterletConfig, error)
+}
+
+// List lists all KlusterletConfigs in the indexer.
+func (m *mockKlusterletConfigLister) List(selector labels.Selector) ([]*klusterletconfigv1alpha1.KlusterletConfig, error) {
+	if m.ListFunc != nil {
+		return m.ListFunc(selector)
+	}
+	return nil, nil
+}
+
+// Get retrieves the KlusterletConfig from the index for a given name.
+func (m *mockKlusterletConfigLister) Get(name string) (*klusterletconfigv1alpha1.KlusterletConfig, error) {
+	if m.GetFunc != nil {
+		return m.GetFunc(name)
+	}
+	return nil, nil
+}


### PR DESCRIPTION
Story: https://issues.redhat.com/browse/ACM-10074

![image](https://github.com/stolostron/managedcluster-import-controller/assets/11444421/75b05b3b-bfdd-49ba-9950-d1d1c1f4d7d0)

We add global klusterletconfig related code in 2 places:
* agentregistration server
* import-config-controller

Currently we are only required to support 1 special "global" klustereletconfig, but in the future if we want to support multiple klusterletconfig, we need to refactor more.