### PR TITLE
Return short-term token in agent-regstration endpoint.

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -65,12 +65,13 @@ const (
 
 /* #nosec */
 const (
-	ImportSecretNameSuffix         = "import"
-	ImportSecretImportYamlKey      = "import.yaml"
-	ImportSecretCRDSYamlKey        = "crds.yaml"        // #nosec G101
-	ImportSecretCRDSV1YamlKey      = "crdsv1.yaml"      // #nosec G101
-	ImportSecretCRDSV1beta1YamlKey = "crdsv1beta1.yaml" // #nosec G101
-	ImportSecretTokenExpiration    = "expiration"
+	ImportSecretNameSuffix             = "import"
+	ImportSecretImportYamlKey          = "import.yaml"
+	ImportSecretCRDSYamlKey            = "crds.yaml"        // #nosec G101
+	ImportSecretCRDSV1YamlKey          = "crdsv1.yaml"      // #nosec G101
+	ImportSecretCRDSV1beta1YamlKey     = "crdsv1beta1.yaml" // #nosec G101
+	ImportSecretTokenExpiration        = "expiration"
+	DefaultSecretTokenExpirationSecond = 360 * 24 * 60 * 60 // 360 days
 )
 
 const (


### PR DESCRIPTION
Fix: https://issues.redhat.com/browse/ACM-12277

In this PR, we change agent-registration to return a short-term bootstrapkubeconfig secret if the `duration` param in the URL is set, for example:

```sh
curl --cacert ca.crt -H "Authorization: Bearer $token" [https://$agent_registration_host/agent-registration/manifests/cluster-e2e-test-agent?klusterletconfig\=default\&expiration\=4h](https://$agent_registration_host/agent-registration/manifests/cluster-e2e-test-agent?klusterletconfig=default&duration=4h)
```