### PR TITLE
Fix flaky e2e error.

### DIFF
--- a/pkg/controller/autoimport/autoimport_controller_test.go
+++ b/pkg/controller/autoimport/autoimport_controller_test.go
@@ -646,7 +646,7 @@ func TestReconcile(t *testing.T) {
 				helpers.NewManagedClusterEventRecorder(ctx, kubeClient),
 			)
 
-			req := reconcile.Request{NamespacedName: types.NamespacedName{Namespace: managedClusterName}}
+			req := reconcile.Request{NamespacedName: types.NamespacedName{Name: managedClusterName}}
 			_, err := r.Reconcile(ctx, req)
 			if c.expectedErr && err == nil {
 				t.Errorf("name: %v, expected error, but failed", c.name)

--- a/pkg/controller/importstatus/importstatus_controller.go
+++ b/pkg/controller/importstatus/importstatus_controller.go
@@ -74,6 +74,8 @@ func (r *ReconcileImportStatus) Reconcile(ctx context.Context, request reconcile
 		return reconcile.Result{}, nil
 	}
 
+	reqLogger.V(5).Info("Reconciling managedcluster", "managedCluster", managedClusterName)
+
 	// This controller will only add/update the ImportSucceededCondition condition in following 2 cases:
 	// - Add the condition when it does not exist
 	// - Set the condition status to True when manifestworks are available
@@ -104,7 +106,6 @@ func (r *ReconcileImportStatus) Reconcile(ctx context.Context, request reconcile
 		return reconcile.Result{}, err
 	}
 	if !available {
-
 		reqLogger.V(5).Info("Klusterlet manifestworks are not available")
 		return reconcile.Result{}, nil
 	}

--- a/pkg/controller/manifestwork/manifestwork_controller.go
+++ b/pkg/controller/manifestwork/manifestwork_controller.go
@@ -131,6 +131,7 @@ func (r *ReconcileManifestWork) Reconcile(ctx context.Context, request reconcile
 	importSecretName := fmt.Sprintf("%s-%s", managedClusterName, constants.ImportSecretNameSuffix)
 	importSecret, err := r.informerHolder.ImportSecretLister.Secrets(managedClusterName).Get(importSecretName)
 	if errors.IsNotFound(err) {
+		reqLogger.V(5).Info("The import secret is not found", "importSecret", importSecretName)
 		return reconcile.Result{}, nil
 	}
 	if err != nil {

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -16,7 +16,6 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 	workv1lister "open-cluster-management.io/api/client/work/listers/work/v1"
-	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	workv1 "open-cluster-management.io/api/work/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -94,20 +93,6 @@ func NewHostedWorkSource(workInformer cache.SharedIndexInformer,
 		informer:     workInformer,
 		expectedType: reflect.TypeOf(&workv1.ManifestWork{}),
 		name:         "hosted-manifest-works",
-
-		handler:    handler,
-		predicates: predicates,
-	}
-}
-
-// NewManagedClusterSource return a source for managed cluster
-func NewManagedClusterSource(mcInformer cache.SharedIndexInformer,
-	handler handler.EventHandler,
-	predicates ...predicate.Predicate) *Source {
-	return &Source{
-		informer:     mcInformer,
-		expectedType: reflect.TypeOf(&clusterv1.ManagedCluster{}),
-		name:         "managed-cluster",
 
 		handler:    handler,
 		predicates: predicates,

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -554,7 +554,7 @@ func assertManagedClusterImportSecretApplied(clusterName string, mode ...operato
 			}
 
 			return fmt.Errorf("assert managed cluster %s import secret applied failed", clusterName)
-		}, 5*time.Minute, 1*time.Second).Should(gomega.Succeed())
+		}, 5*time.Minute, 30*time.Second).Should(gomega.Succeed())
 	})
 }
 


### PR DESCRIPTION
## Should not import the cluster if auto-import is disabled

The first error msg is like:

```
Importing a managed cluster with auto-import-secret Should not import the cluster if auto-import is disabled
/home/runner/work/managedcluster-import-controller/managedcluster-import-controller/test/e2e/autoimport_test.go:67
  STEP: Create managed cluster namespace autoimport-test-vj4vh6 @ 08/06/24 15:17:32.354
  STEP: Create auto-import-secret for managed cluster autoimport-test-vj4vh6 with kubeconfig
  
---

[FAILED] in [It] - /home/runner/work/managedcluster-import-controller/managedcluster-import-controller/test/e2e/e2e_suite_test.go:557 @ 08/06/24 15:25:34.43
  STEP: Delete the managed cluster autoimport-test-vj4vh6 @ 08/06/24 15:25:34.43
  STEP: Should delete the managed cluster autoimport-test-vj4vh6 @ 08/06/24 15:25:34.435
  DEBUG: spending time: 1.01 seconds
  STEP: Should delete the managed cluster namespace autoimport-test-vj4vh6 @ 08/06/24 15:25:35.44
  DEBUG: spending time: 5.01 seconds
  STEP: Should delete the open-cluster-management-agent namespace @ 08/06/24 15:25:40.455
  DEBUG: delete the open-cluster-management-agent namespace spending time: 0.00 seconds
  STEP: Should delete the klusterlet crd @ 08/06/24 15:25:40.456
  DEBUG: delete klusterlet crd spending time: 0.00 seconds
• [FAILED] [488.104 seconds]
Importing a managed cluster with auto-import-secret [It] Should not import the cluster if auto-import is disabled
/home/runner/work/managedcluster-import-controller/managedcluster-import-controller/test/e2e/autoimport_test.go:67

  [FAILED] Timed out after 300.000s.
  Expected success, but got an error:
      <*errors.errorString | 0xc000c8c110>: 
      assert managed cluster autoimport-test-vj4vh6 import secret applied failed
      {
          s: "assert managed cluster autoimport-test-vj4vh6 import secret applied failed",
      }
  In [It] at: /home/runner/work/managedcluster-import-controller/managedcluster-import-controller/test/e2e/e2e_suite_test.go:557 @ 08/06/24 15:25:34.43
```
---

The root cause is that: in the auto-import-controller, we are using 2 managedcluster informer:

The first informer used to trigger Reconcile is from main.go:

https://github.com/stolostron/managedcluster-import-controller/blob/716acc3a8e6b0ee2f585e10ef0ae47c8bfd165f7/cmd/manager/main.go#L212

https://github.com/stolostron/managedcluster-import-controller/blob/716acc3a8e6b0ee2f585e10ef0ae47c8bfd165f7/pkg/controller/autoimport/manager.go#L99-L100

The second informer which also provide the ability of `r.client`(the `mgr.GetClient()`) is because anther controller `Watches` the managedcluster resource:

https://github.com/stolostron/managedcluster-import-controller/blob/716acc3a8e6b0ee2f585e10ef0ae47c8bfd165f7/pkg/controller/selfmanagedcluster/manager.go#L64-L65

When first informer trigger reconcile, it doesn't generatee the second informer's cache get updated.

That where the inconsistent happens.