### PR TITLE
Change `Watches` to `WatchesMetadata`.

### DIFF
--- a/pkg/controller/importconfig/manager.go
+++ b/pkg/controller/importconfig/manager.go
@@ -130,7 +130,7 @@ func Add(ctx context.Context,
 					UpdateFunc:  func(e event.UpdateEvent) bool { return true },
 				})),
 		).
-		Watches(
+		WatchesMetadata(
 			&corev1.Secret{},
 			&enqueueManagedClusterByBootstrapKubeConfigSecrets{
 				managedclusterIndexer:   informerHolder.ManagedClusterInformer.GetIndexer(),
@@ -151,7 +151,7 @@ func Add(ctx context.Context,
 				},
 			}),
 		).
-		Watches(
+		WatchesMetadata(
 			&corev1.ConfigMap{},
 			&enqueueManagedClusterByCustomizedCAConfigmaps{
 				managedclusterIndexer:   informerHolder.ManagedClusterInformer.GetIndexer(),


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/ACM-14605

WatchesMetadata doesn't unmarshal the data part and save a lot of memory.

Tested with 200 managedcluster, the base memory usage(0 managed cluster) is 145Mb:
* `Watches` uses 400Mb
* `WatchesMetadata` uses 174Mb.