### PR TITLE
Fix typo `regitration` to `registration`

### DIFF
--- a/build/setup-import-controller.sh
+++ b/build/setup-import-controller.sh
@@ -170,7 +170,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: managedcluster-import-controller-agent-regitration-client
+  name: managedcluster-import-controller-agent-registration-client
 subjects:
   - kind: ServiceAccount
     name: managed-cluster-import-e2e-agent-registration-sa

--- a/deploy/agentregistration/clientclusterrole.yaml
+++ b/deploy/agentregistration/clientclusterrole.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: managedcluster-import-controller-agent-regitration-client
+  name: managedcluster-import-controller-agent-registration-client
 rules:
 - nonResourceURLs: ["/agent-registration/*"]
   verbs: ["get"]


### PR DESCRIPTION
Also updated in backplane-operator: https://github.com/stolostron/backplane-operator/pull/1077