### PR TITLE
Refactor: controller `AddToManager`

### DIFF
--- a/pkg/controller/autoimport/autoimport_controller.go
+++ b/pkg/controller/autoimport/autoimport_controller.go
@@ -29,7 +29,7 @@ import (
 	"github.com/stolostron/managedcluster-import-controller/pkg/source"
 )
 
-var log = logf.Log.WithName(controllerName)
+var log = logf.Log.WithName(ControllerName)
 
 // ReconcileAutoImport reconciles the managed cluster auto import secret to import the managed cluster
 type ReconcileAutoImport struct {

--- a/pkg/controller/autoimport/manager.go
+++ b/pkg/controller/autoimport/manager.go
@@ -27,7 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
-const controllerName = "autoimport-controller"
+const ControllerName = "autoimport-controller"
 
 // Add creates a new autoimport controller and adds it to the Manager.
 // The Manager will set fields on the Controller and Start it when the Manager is Started.
@@ -35,9 +35,9 @@ func Add(ctx context.Context,
 	mgr manager.Manager,
 	clientHolder *helpers.ClientHolder,
 	informerHolder *source.InformerHolder,
-	mcRecorder kevents.EventRecorder) (string, error) {
+	mcRecorder kevents.EventRecorder) error {
 
-	err := ctrl.NewControllerManagedBy(mgr).Named(controllerName).
+	err := ctrl.NewControllerManagedBy(mgr).Named(ControllerName).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: helpers.GetMaxConcurrentReconciles(),
 		}).
@@ -133,9 +133,9 @@ func Add(ctx context.Context,
 			clientHolder.RuntimeClient,
 			clientHolder.KubeClient,
 			informerHolder,
-			helpers.NewEventRecorder(clientHolder.KubeClient, controllerName),
+			helpers.NewEventRecorder(clientHolder.KubeClient, ControllerName),
 			mcRecorder,
 		))
 
-	return controllerName, err
+	return err
 }

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -25,7 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-var log = logf.Log.WithName(controllerName)
+var log = logf.Log.WithName(ControllerName)
 
 // ReconcileClusterDeployment reconciles the clusterdeployment that is in the managed cluster namespace
 // to import the managed cluster

--- a/pkg/controller/clusterdeployment/manager.go
+++ b/pkg/controller/clusterdeployment/manager.go
@@ -31,7 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-const controllerName = "clusterdeployment-controller"
+const ControllerName = "clusterdeployment-controller"
 
 // Add creates a new managedcluster controller and adds it to the Manager.
 // The Manager will set fields on the Controller and Start it when the Manager is Started.
@@ -39,9 +39,9 @@ func Add(ctx context.Context,
 	mgr manager.Manager,
 	clientHolder *helpers.ClientHolder,
 	informerHolder *source.InformerHolder,
-	mcRecorder kevents.EventRecorder) (string, error) {
+	mcRecorder kevents.EventRecorder) error {
 
-	err := ctrl.NewControllerManagedBy(mgr).Named(controllerName).
+	err := ctrl.NewControllerManagedBy(mgr).Named(ControllerName).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: helpers.GetMaxConcurrentReconciles(),
 		}).
@@ -139,9 +139,9 @@ func Add(ctx context.Context,
 			clientHolder.RuntimeClient,
 			clientHolder.KubeClient,
 			informerHolder,
-			helpers.NewEventRecorder(clientHolder.KubeClient, controllerName),
+			helpers.NewEventRecorder(clientHolder.KubeClient, ControllerName),
 			mcRecorder,
 		))
 
-	return controllerName, err
+	return err
 }

--- a/pkg/controller/clusternamespacedeletion/controller.go
+++ b/pkg/controller/clusternamespacedeletion/controller.go
@@ -27,7 +27,7 @@ import (
 )
 
 var (
-	log                        = logf.Log.WithName(controllerName)
+	log                        = logf.Log.WithName(ControllerName)
 	podDeletionGracePeriod     = 10 * time.Second
 	hostedClusterRequeuePeriod = 1 * time.Minute
 )

--- a/pkg/controller/clusternamespacedeletion/manager.go
+++ b/pkg/controller/clusternamespacedeletion/manager.go
@@ -10,7 +10,6 @@ import (
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	kevents "k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -26,20 +25,17 @@ import (
 
 	clustercontroller "github.com/stolostron/managedcluster-import-controller/pkg/controller/managedcluster"
 	"github.com/stolostron/managedcluster-import-controller/pkg/helpers"
-	"github.com/stolostron/managedcluster-import-controller/pkg/source"
 )
 
-const controllerName = "clusternamespacedeletion-controller"
+const ControllerName = "clusternamespacedeletion-controller"
 
 // Add creates a new managedcluster controller and adds it to the Manager.
 // The Manager will set fields on the Controller and Start it when the Manager is Started.
 func Add(ctx context.Context,
 	mgr manager.Manager,
-	clientHolder *helpers.ClientHolder,
-	_ *source.InformerHolder,
-	mcRecorder kevents.EventRecorder) (string, error) {
+	clientHolder *helpers.ClientHolder) error {
 
-	err := ctrl.NewControllerManagedBy(mgr).Named(controllerName).
+	err := ctrl.NewControllerManagedBy(mgr).Named(ControllerName).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: helpers.GetMaxConcurrentReconciles(),
 		}).
@@ -177,8 +173,8 @@ func Add(ctx context.Context,
 		Complete(&ReconcileClusterNamespaceDeletion{
 			client:    clientHolder.RuntimeClient,
 			apiReader: clientHolder.RuntimeAPIReader,
-			recorder:  helpers.NewEventRecorder(clientHolder.KubeClient, controllerName),
+			recorder:  helpers.NewEventRecorder(clientHolder.KubeClient, ControllerName),
 		})
 
-	return controllerName, err
+	return err
 }

--- a/pkg/controller/clusternamespacedeletion/suite_test.go
+++ b/pkg/controller/clusternamespacedeletion/suite_test.go
@@ -97,8 +97,7 @@ var _ = ginkgo.BeforeSuite(func() {
 		KubeClient:       k8sClient,
 	}
 
-	_, err = Add(context.TODO(), mgr, clientHolder, nil,
-		helpers.NewManagedClusterEventRecorder(context.TODO(), clientHolder.KubeClient))
+	err = Add(context.TODO(), mgr, clientHolder)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	go func() {

--- a/pkg/controller/csr/manager.go
+++ b/pkg/controller/csr/manager.go
@@ -6,7 +6,6 @@ import (
 	"context"
 
 	certificatesv1 "k8s.io/api/certificates/v1"
-	kevents "k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -16,20 +15,17 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"github.com/stolostron/managedcluster-import-controller/pkg/helpers"
-	"github.com/stolostron/managedcluster-import-controller/pkg/source"
 )
 
-const controllerName = "csr-controller"
+const ControllerName = "csr-controller"
 
 // Add creates a new CSR Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(ctx context.Context,
 	mgr manager.Manager,
-	clientHolder *helpers.ClientHolder,
-	_ *source.InformerHolder,
-	mcRecorder kevents.EventRecorder) (string, error) {
+	clientHolder *helpers.ClientHolder) error {
 
-	err := ctrl.NewControllerManagedBy(mgr).Named(controllerName).
+	err := ctrl.NewControllerManagedBy(mgr).Named(ControllerName).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: helpers.GetMaxConcurrentReconciles(),
 		}).
@@ -48,8 +44,8 @@ func Add(ctx context.Context,
 			})).
 		Complete(&ReconcileCSR{
 			clientHolder: clientHolder,
-			recorder:     helpers.NewEventRecorder(clientHolder.KubeClient, controllerName),
+			recorder:     helpers.NewEventRecorder(clientHolder.KubeClient, ControllerName),
 		})
 
-	return controllerName, err
+	return err
 }

--- a/pkg/controller/hosted/controller.go
+++ b/pkg/controller/hosted/controller.go
@@ -40,7 +40,7 @@ var manifestFiles embed.FS
 
 var klusterletHostedExternalKubeconfig = "manifests/external_managed_secret.yaml"
 
-var log = logf.Log.WithName(controllerName)
+var log = logf.Log.WithName(ControllerName)
 
 // ReconcileHosted reconciles the Hosted mode ManagedClusters of the ManifestWorks object
 type ReconcileHosted struct {

--- a/pkg/controller/hosted/manager.go
+++ b/pkg/controller/hosted/manager.go
@@ -30,7 +30,7 @@ import (
 	"github.com/stolostron/managedcluster-import-controller/pkg/source"
 )
 
-const controllerName = "hosted-manifestwork-controller"
+const ControllerName = "hosted-manifestwork-controller"
 
 // Add creates a new manifestwork controller and adds it to the Manager.
 // The Manager will set fields on the Controller and Start it when the Manager is Started.
@@ -38,9 +38,9 @@ func Add(ctx context.Context,
 	mgr manager.Manager,
 	clientHolder *helpers.ClientHolder,
 	informerHolder *source.InformerHolder,
-	mcRecorder kevents.EventRecorder) (string, error) {
+	mcRecorder kevents.EventRecorder) error {
 
-	err := ctrl.NewControllerManagedBy(mgr).Named(controllerName).
+	err := ctrl.NewControllerManagedBy(mgr).Named(ControllerName).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: helpers.GetMaxConcurrentReconciles(),
 		}).
@@ -139,10 +139,10 @@ func Add(ctx context.Context,
 			clientHolder,
 			informerHolder,
 			mgr.GetScheme(),
-			helpers.NewEventRecorder(clientHolder.KubeClient, controllerName),
+			helpers.NewEventRecorder(clientHolder.KubeClient, ControllerName),
 			mcRecorder,
 		))
-	return controllerName, err
+	return err
 }
 
 func isHostedModeObject(object client.Object) bool {

--- a/pkg/controller/importconfig/importconfig_controller.go
+++ b/pkg/controller/importconfig/importconfig_controller.go
@@ -28,7 +28,7 @@ import (
 	apiconstants "github.com/stolostron/cluster-lifecycle-api/constants"
 )
 
-var log = logf.Log.WithName(controllerName)
+var log = logf.Log.WithName(ControllerName)
 
 // ReconcileImportConfig reconciles a managed cluster to prepare its import secret
 type ReconcileImportConfig struct {

--- a/pkg/controller/importconfig/manager.go
+++ b/pkg/controller/importconfig/manager.go
@@ -11,7 +11,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
-	kevents "k8s.io/client-go/tools/events"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -29,20 +28,19 @@ import (
 	"github.com/stolostron/managedcluster-import-controller/pkg/source"
 )
 
-const controllerName = "importconfig-controller"
+const ControllerName = "importconfig-controller"
 
 // Add creates a new importconfig controller and adds it to the Manager.
 // The Manager will set fields on the Controller and Start it when the Manager is Started.
 func Add(ctx context.Context,
 	mgr manager.Manager,
 	clientHolder *helpers.ClientHolder,
-	informerHolder *source.InformerHolder,
-	mcRecorder kevents.EventRecorder) (string, error) {
+	informerHolder *source.InformerHolder) error {
 
 	// All bootstrap kubeconfigs should created in the same pod namespace
 	podNS := os.Getenv(constants.PodNamespaceEnvVarName)
 
-	err := ctrl.NewControllerManagedBy(mgr).Named(controllerName).
+	err := ctrl.NewControllerManagedBy(mgr).Named(ControllerName).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: helpers.GetMaxConcurrentReconciles(),
 		}).
@@ -184,7 +182,7 @@ func Add(ctx context.Context,
 			clientHolder:           clientHolder,
 			klusterletconfigLister: informerHolder.KlusterletConfigLister,
 			scheme:                 mgr.GetScheme(),
-			recorder:               helpers.NewEventRecorder(clientHolder.KubeClient, controllerName),
+			recorder:               helpers.NewEventRecorder(clientHolder.KubeClient, ControllerName),
 		})
-	return controllerName, err
+	return err
 }

--- a/pkg/controller/importstatus/importstatus_controller.go
+++ b/pkg/controller/importstatus/importstatus_controller.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stolostron/managedcluster-import-controller/pkg/helpers"
 )
 
-var log = logf.Log.WithName(controllerName)
+var log = logf.Log.WithName(ControllerName)
 
 // ReconcileImportStatus reconciles the klusterlet manifestworks to judge whether the cluster is imported successfully
 type ReconcileImportStatus struct {

--- a/pkg/controller/importstatus/manager.go
+++ b/pkg/controller/importstatus/manager.go
@@ -27,7 +27,7 @@ import (
 	"github.com/stolostron/managedcluster-import-controller/pkg/source"
 )
 
-const controllerName = "import-status-controller"
+const ControllerName = "import-status-controller"
 
 // Add creates a new manifestwork controller and adds it to the Manager.
 // The Manager will set fields on the Controller and Start it when the Manager is Started.
@@ -35,9 +35,9 @@ func Add(ctx context.Context,
 	mgr manager.Manager,
 	clientHolder *helpers.ClientHolder,
 	informerHolder *source.InformerHolder,
-	mcRecorder kevents.EventRecorder) (string, error) {
+	mcRecorder kevents.EventRecorder) error {
 
-	err := ctrl.NewControllerManagedBy(mgr).Named(controllerName).
+	err := ctrl.NewControllerManagedBy(mgr).Named(ControllerName).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: helpers.GetMaxConcurrentReconciles(),
 		}).
@@ -83,7 +83,7 @@ func Add(ctx context.Context,
 			mcRecorder,
 		))
 
-	return controllerName, err
+	return err
 }
 
 func isDefaultModeObject(object client.Object) bool {

--- a/pkg/controller/managedcluster/managedcluster_controller.go
+++ b/pkg/controller/managedcluster/managedcluster_controller.go
@@ -32,7 +32,7 @@ const (
 	createdViaOther = "other"
 )
 
-var log = logf.Log.WithName(controllerName)
+var log = logf.Log.WithName(ControllerName)
 
 // ReconcileManagedCluster reconciles a ManagedCluster object
 type ReconcileManagedCluster struct {

--- a/pkg/controller/managedcluster/manager.go
+++ b/pkg/controller/managedcluster/manager.go
@@ -19,20 +19,18 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"github.com/stolostron/managedcluster-import-controller/pkg/helpers"
-	"github.com/stolostron/managedcluster-import-controller/pkg/source"
 )
 
-const controllerName = "managedcluster-controller"
+const ControllerName = "managedcluster-controller"
 
 // Add creates a new managedcluster controller and adds it to the Manager.
 // The Manager will set fields on the Controller and Start it when the Manager is Started.
 func Add(ctx context.Context,
 	mgr manager.Manager,
 	clientHolder *helpers.ClientHolder,
-	_ *source.InformerHolder,
-	mcRecorder kevents.EventRecorder) (string, error) {
+	mcRecorder kevents.EventRecorder) error {
 
-	err := ctrl.NewControllerManagedBy(mgr).Named(controllerName).
+	err := ctrl.NewControllerManagedBy(mgr).Named(ControllerName).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: helpers.GetMaxConcurrentReconciles(),
 		}).
@@ -66,9 +64,9 @@ func Add(ctx context.Context,
 		).
 		Complete(NewReconcileManagedCluster(
 			clientHolder.RuntimeClient,
-			helpers.NewEventRecorder(clientHolder.KubeClient, controllerName),
+			helpers.NewEventRecorder(clientHolder.KubeClient, ControllerName),
 			mcRecorder,
 		))
 
-	return controllerName, err
+	return err
 }

--- a/pkg/controller/manifestwork/manager.go
+++ b/pkg/controller/manifestwork/manager.go
@@ -27,7 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
-const controllerName = "manifestwork-controller"
+const ControllerName = "manifestwork-controller"
 
 // Add creates a new manifestwork controller and adds it to the Manager.
 // The Manager will set fields on the Controller and Start it when the Manager is Started.
@@ -35,9 +35,9 @@ func Add(ctx context.Context,
 	mgr manager.Manager,
 	clientHolder *helpers.ClientHolder,
 	informerHolder *source.InformerHolder,
-	mcRecorder kevents.EventRecorder) (string, error) {
+	mcRecorder kevents.EventRecorder) error {
 
-	err := ctrl.NewControllerManagedBy(mgr).Named(controllerName).
+	err := ctrl.NewControllerManagedBy(mgr).Named(ControllerName).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: helpers.GetMaxConcurrentReconciles(),
 		}).
@@ -98,10 +98,10 @@ func Add(ctx context.Context,
 			clientHolder,
 			informerHolder,
 			mgr.GetScheme(),
-			helpers.NewEventRecorder(clientHolder.KubeClient, controllerName),
+			helpers.NewEventRecorder(clientHolder.KubeClient, ControllerName),
 			mcRecorder,
 		))
-	return controllerName, err
+	return err
 }
 
 func isDefaultModeObject(object client.Object) bool {

--- a/pkg/controller/manifestwork/manifestwork_controller.go
+++ b/pkg/controller/manifestwork/manifestwork_controller.go
@@ -31,7 +31,7 @@ import (
 	"github.com/stolostron/managedcluster-import-controller/pkg/source"
 )
 
-var log = logf.Log.WithName(controllerName)
+var log = logf.Log.WithName(ControllerName)
 
 // ReconcileManifestWork reconciles the ManagedClusters of the ManifestWorks object
 type ReconcileManifestWork struct {

--- a/pkg/controller/selfmanagedcluster/manager.go
+++ b/pkg/controller/selfmanagedcluster/manager.go
@@ -27,7 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
-const controllerName = "selfmanagedcluster-controller"
+const ControllerName = "selfmanagedcluster-controller"
 
 // Add creates a new self managed cluster controller and adds it to the Manager.
 // The Manager will set fields on the Controller and Start it when the Manager is Started.
@@ -35,9 +35,9 @@ func Add(ctx context.Context,
 	mgr manager.Manager,
 	clientHolder *helpers.ClientHolder,
 	informerHolder *source.InformerHolder,
-	mcRecorder kevents.EventRecorder) (string, error) {
+	mcRecorder kevents.EventRecorder) error {
 
-	err := ctrl.NewControllerManagedBy(mgr).Named(controllerName).
+	err := ctrl.NewControllerManagedBy(mgr).Named(ControllerName).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: helpers.GetMaxConcurrentReconciles(),
 		}).
@@ -125,8 +125,8 @@ func Add(ctx context.Context,
 			clientHolder,
 			informerHolder,
 			mgr.GetRESTMapper(),
-			helpers.NewEventRecorder(clientHolder.KubeClient, controllerName),
+			helpers.NewEventRecorder(clientHolder.KubeClient, ControllerName),
 			mcRecorder,
 		))
-	return controllerName, err
+	return err
 }

--- a/pkg/controller/selfmanagedcluster/selfmanagedcluster_controller.go
+++ b/pkg/controller/selfmanagedcluster/selfmanagedcluster_controller.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stolostron/managedcluster-import-controller/pkg/source"
 )
 
-var log = logf.Log.WithName(controllerName)
+var log = logf.Log.WithName(ControllerName)
 
 // ReconcileLocalCluster reconciles the import secret of a self managed cluster to import the managed cluster
 type ReconcileLocalCluster struct {


### PR DESCRIPTION
Simply `AddToManager`, and:
1. When we call `Add` function, only need to input the varibles the controller actually needs. For example, csrContoller doesn't need `informer` and `recoder`, now it doesn't need put them in the `Add`'s `inputs`.
2. In the future, if we want to add customized varibles to specific controller, for example, if we want to add `flightctl flag` to csr controller, without affect other controllers.
3. Now hosted controller can handle like other controllers. Unified the code style.