### PR TITLE
Append the current kubeconfig name into registrationConfiguration.bootstrapKubeConfigs.localSecretsConfig.kubeConfigSecrets

### DIFF
--- a/pkg/bootstrap/render.go
+++ b/pkg/bootstrap/render.go
@@ -353,6 +353,10 @@ func (b *KlusterletManifestsConfig) Generate(ctx context.Context, clientHolder *
 				Mode:    operatorv1.FeatureGateModeTypeEnable,
 			})
 		registrationConfiguration.BootstrapKubeConfigs = b.klusterletconfig.Spec.BootstrapKubeConfigs
+		registrationConfiguration.BootstrapKubeConfigs.LocalSecrets.KubeConfigSecrets = append(
+			registrationConfiguration.BootstrapKubeConfigs.LocalSecrets.KubeConfigSecrets, operatorv1.KubeConfigSecret{
+				Name: constants.DefaultBootstrapHubKubeConfigSecretName + "-current-hub",
+			})
 
 		bootstrapKubeConfigSecrets, err := convertKubeConfigSecrets(ctx,
 			b.klusterletconfig.Spec.BootstrapKubeConfigs.LocalSecrets.KubeConfigSecrets, clientHolder.KubeClient)

--- a/pkg/bootstrap/render_test.go
+++ b/pkg/bootstrap/render_test.go
@@ -712,12 +712,12 @@ func TestKlusterletConfigGenerate(t *testing.T) {
 				if klusterlet.Spec.RegistrationConfiguration.BootstrapKubeConfigs.Type != operatorv1.LocalSecrets {
 					t.Fatalf("the klusterlet bootstrap kubeconfig type is not %s", operatorv1.LocalSecrets)
 				}
-				if len(klusterlet.Spec.RegistrationConfiguration.BootstrapKubeConfigs.LocalSecrets.KubeConfigSecrets) != 2 {
-					t.Fatalf("the klusterlet bootstrap kubeconfig secrets count is not 2")
+				if len(klusterlet.Spec.RegistrationConfiguration.BootstrapKubeConfigs.LocalSecrets.KubeConfigSecrets) != 3 {
+					t.Fatalf("the klusterlet bootstrap kubeconfig secrets count is not 3")
 				}
 				for _, secret := range klusterlet.Spec.RegistrationConfiguration.BootstrapKubeConfigs.LocalSecrets.KubeConfigSecrets {
-					if secret.Name != "bootstrapkubeconfig-hub1" && secret.Name != "bootstrapkubeconfig-hub2" {
-						t.Fatalf("the klusterlet bootstrap kubeconfig secret name is not bootstrapkubeconfig-hub1 or bootstrapkubeconfig-hub2")
+					if secret.Name != "bootstrapkubeconfig-hub1" && secret.Name != "bootstrapkubeconfig-hub2" && secret.Name != "bootstrap-hub-kubeconfig-current-hub" {
+						t.Fatalf("the klusterlet bootstrap kubeconfig secret name is not bootstrapkubeconfig-hub1 or bootstrapkubeconfig-hub2 or bootstrap-hub-kubeconfig-current-hub")
 					}
 				}
 				if klusterlet.Spec.RegistrationConfiguration.BootstrapKubeConfigs.LocalSecrets.HubConnectionTimeoutSeconds != 500 {


### PR DESCRIPTION
In this PR https://github.com/stolostron/managedcluster-import-controller/pull/404, we put the secret into import.yaml so that the secret can be created in `open-cluster-management-agent` namespace. 
This PR is to put the `-current-hub` secret name into registrationConfiguration.bootstrapKubeConfigs.localSecretsConfig.kubeConfigSecrets so that if the user only provide one secret, we will append the original one. Then it can meet our desired behaviour.

ref: https://issues.redhat.com/browse/ACM-14994