### PR TITLE
Move `FliesToObjects` function into the `helper` pkg.

### DIFF
--- a/pkg/bootstrap/render.go
+++ b/pkg/bootstrap/render.go
@@ -422,7 +422,7 @@ func (b *KlusterletManifestsConfig) GenerateKlusterletCRDsV1Beta1() ([]byte, err
 }
 
 func GenerateHubBootstrapRBACObjects(managedClusterName string) ([]runtime.Object, error) {
-	return filesToObjects(hubFiles, struct {
+	return helpers.FilesToObjects(hubFiles, struct {
 		ManagedClusterName          string
 		ManagedClusterNamespace     string
 		BootstrapServiceAccountName string
@@ -430,7 +430,7 @@ func GenerateHubBootstrapRBACObjects(managedClusterName string) ([]runtime.Objec
 		ManagedClusterName:          managedClusterName,
 		ManagedClusterNamespace:     managedClusterName,
 		BootstrapServiceAccountName: GetBootstrapSAName(managedClusterName),
-	})
+	}, &ManifestFiles)
 }
 
 func filesToTemplateBytes(files []string, config interface{}) ([]byte, error) {
@@ -447,19 +447,6 @@ func filesToTemplateBytes(files []string, config interface{}) ([]byte, error) {
 		manifests.WriteString(fmt.Sprintf("%s%s", constants.YamlSperator, string(b)))
 	}
 	return manifests.Bytes(), nil
-}
-
-func filesToObjects(files []string, config interface{}) ([]runtime.Object, error) {
-	objects := []runtime.Object{}
-	for _, file := range files {
-		template, err := ManifestFiles.ReadFile(file)
-		if err != nil {
-			return nil, err
-		}
-
-		objects = append(objects, helpers.MustCreateObjectFromTemplate(file, template, config))
-	}
-	return objects, nil
 }
 
 // installNoOperator return true if operator is not to be installed.

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -6,6 +6,7 @@ package helpers
 import (
 	"bytes"
 	"context"
+	"embed"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -1106,4 +1107,17 @@ func HasCertificates(supersetCertData, subsetCertData []byte) (bool, error) {
 		}
 	}
 	return true, nil
+}
+
+func FilesToObjects(files []string, config interface{}, manifestFiles *embed.FS) ([]runtime.Object, error) {
+	objects := []runtime.Object{}
+	for _, file := range files {
+		template, err := manifestFiles.ReadFile(file)
+		if err != nil {
+			return nil, err
+		}
+
+		objects = append(objects, MustCreateObjectFromTemplate(file, template, config))
+	}
+	return objects, nil
 }


### PR DESCRIPTION
Render files into objects and use `helper.ApplyResources` is not only needed inside the `bootstrap` repo.  

For example, in the `flightctl` case, if `flightctl` is enabled, we want to apply some resources. It would be convenient if `FilesToObjects` is a common method in the helper package.