### PR TITLE
refactor to simplify the bootstrap kubeconfig creation logic

### DIFF
--- a/pkg/controller/agentregistration/server.go
+++ b/pkg/controller/agentregistration/server.go
@@ -118,7 +118,20 @@ func RunAgentRegistrationServer(ctx context.Context, port int, clientHolder *hel
 			}
 		}
 
-		bootstrapkubeconfig, err := bootstrap.CreateBootstrapKubeConfig(ctx, clientHolder, ns, token, mergedKlusterletConfig)
+		// get the latest kube apiserver configuration
+		kubeAPIServer, proxyURL, caData, err := bootstrap.GetKubeAPIServerConfig(
+			ctx, clientHolder, ns, mergedKlusterletConfig)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		ctxClusterName, err := bootstrap.GetKubeconfigClusterName(ctx, clientHolder.RuntimeClient)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		bootstrapkubeconfig, err := bootstrap.CreateBootstrapKubeConfig(ctxClusterName, kubeAPIServer, proxyURL, caData, token)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/pkg/controller/importconfig/cluster_info_test.go
+++ b/pkg/controller/importconfig/cluster_info_test.go
@@ -17,14 +17,17 @@ import (
 	"github.com/stolostron/managedcluster-import-controller/pkg/constants"
 	"github.com/stolostron/managedcluster-import-controller/pkg/helpers"
 	testinghelpers "github.com/stolostron/managedcluster-import-controller/pkg/helpers/testing"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	operatorv1 "open-cluster-management.io/api/operator/v1"
 
 	ocinfrav1 "github.com/openshift/api/config/v1"
 
+	authv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubefake "k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	clientcmdlatest "k8s.io/client-go/tools/clientcmd/api/latest"
 
@@ -32,7 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-func TestGetBootstrapKubeConfigDataFromImportSecret(t *testing.T) {
+func TestBuildBootstrapKubeconfigData(t *testing.T) {
 	certData1, _, _ := testinghelpers.NewRootCA("test ca1")
 	certData2, keyData2, _ := testinghelpers.NewRootCA("test ca2")
 
@@ -57,6 +60,12 @@ func TestGetBootstrapKubeConfigDataFromImportSecret(t *testing.T) {
 	}
 
 	apiserverConfig := &ocinfrav1.APIServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+	}
+
+	apiserverConfigWithCustomCA := &ocinfrav1.APIServer{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "cluster",
 		},
@@ -94,76 +103,134 @@ func TestGetBootstrapKubeConfigDataFromImportSecret(t *testing.T) {
 		Type: corev1.SecretTypeTLS,
 	}
 
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testcluster-bootstrap-sa",
+			Namespace: "testcluster",
+		},
+		Secrets: []corev1.ObjectReference{
+			{
+				Name:      "testcluster-bootstrap-sa-token-5pw5c",
+				Namespace: "testcluster",
+			},
+		},
+	}
+
+	saSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testcluster-bootstrap-sa-token-5pw5c",
+			Namespace: "testcluster",
+		},
+		Data: map[string][]byte{
+			"token": []byte("sa-token"),
+		},
+		Type: corev1.SecretTypeServiceAccountToken,
+	}
+
 	type wantData struct {
-		serverURL   string
-		useInsecure bool
-		certData    []byte
-		token       string
+		serverURL string
+		ca        string
+		certData  []byte
+		token     string
 	}
 	tests := []struct {
 		name             string
 		clientObjs       []client.Object
 		runtimeObjs      []runtime.Object
+		selfManaged      bool
 		klusterletConfig *klusterletconfigv1alpha1.KlusterletConfig
 		want             *wantData
 		wantErr          bool
 	}{
 		{
-			name:    "import secret not exist",
-			wantErr: false,
+			name:        "import secret not exist",
+			clientObjs:  []client.Object{testInfraConfigDNS, apiserverConfig},
+			runtimeObjs: []runtime.Object{cm, sa, saSecret},
+			wantErr:     false,
+			want: &wantData{
+				serverURL: "https://my-dns-name.com:6443",
+				certData:  certData1,
+				token:     "sa-token",
+			},
 		},
 		{
 			name:        "import secret don't have the desired content",
-			runtimeObjs: []runtime.Object{mockImportSecretWithoutContent()},
-			wantErr:     false,
+			clientObjs:  []client.Object{testInfraConfigDNS, apiserverConfig},
+			runtimeObjs: []runtime.Object{cm, mockImportSecretWithoutContent()},
+			want: &wantData{
+				serverURL: "https://my-dns-name.com:6443",
+				certData:  certData1,
+				token:     "fake-token",
+			},
+			wantErr: false,
 		},
 		{
 			name:       "token is expired",
-			clientObjs: []client.Object{testInfraConfigDNS, apiserverConfig},
-			runtimeObjs: []runtime.Object{secretCorrect,
+			clientObjs: []client.Object{testInfraConfigDNS, apiserverConfigWithCustomCA},
+			runtimeObjs: []runtime.Object{cm, secretCorrect,
 				mockImportSecret(t, time.Now().Add(-1*time.Hour),
 					"https://my-dns-name.com:6443",
 					certData2,
 					"mock-token"),
 			},
+			want: &wantData{
+				serverURL: "https://my-dns-name.com:6443",
+				certData:  certData2,
+				token:     "fake-token",
+			},
 			wantErr: false,
 		},
 		{
 			name:       "caData not validate",
-			clientObjs: []client.Object{testInfraConfigDNS, apiserverConfig},
+			clientObjs: []client.Object{testInfraConfigDNS, apiserverConfigWithCustomCA},
 			runtimeObjs: []runtime.Object{secretCorrect,
 				mockImportSecret(t, time.Now().Add(8640*time.Hour),
 					"https://my-dns-name.com:6443",
 					[]byte("wrong"),
 					"mock-token"),
 			},
+			want: &wantData{
+				serverURL: "https://my-dns-name.com:6443",
+				certData:  certData2,
+				token:     "mock-token",
+			},
 			wantErr: false,
 		},
 		{
 			name:       "kubeAPIServer not validate",
-			clientObjs: []client.Object{testInfraConfigDNS, apiserverConfig},
+			clientObjs: []client.Object{testInfraConfigDNS, apiserverConfigWithCustomCA},
 			runtimeObjs: []runtime.Object{secretCorrect,
 				mockImportSecret(t, time.Now().Add(8640*time.Hour),
 					"https://wrong.com:6443",
 					certData2,
 					"mock-token"),
 			},
+			want: &wantData{
+				serverURL: "https://my-dns-name.com:6443",
+				certData:  certData2,
+				token:     "mock-token",
+			},
 			wantErr: false,
 		},
 		{
 			name:       "kubeconfig current context cluster name not match",
-			clientObjs: []client.Object{testInfraConfigWithoutUID, apiserverConfig},
+			clientObjs: []client.Object{testInfraConfigWithoutUID, apiserverConfigWithCustomCA},
 			runtimeObjs: []runtime.Object{secretCorrect,
 				mockImportSecret(t, time.Now().Add(8640*time.Hour),
 					"https://my-dns-name.com:6443",
 					certData2,
 					"mock-token"),
 			},
+			want: &wantData{
+				serverURL: "https://my-dns-name.com:6443",
+				certData:  certData2,
+				token:     "mock-token",
+			},
 			wantErr: false,
 		},
 		{
 			name:       "all fileds are valid",
-			clientObjs: []client.Object{testInfraConfigDNS, apiserverConfig},
+			clientObjs: []client.Object{testInfraConfigDNS, apiserverConfigWithCustomCA},
 			runtimeObjs: []runtime.Object{secretCorrect,
 				mockImportSecret(t, time.Now().Add(8640*time.Hour),
 					"https://my-dns-name.com:6443",
@@ -172,15 +239,14 @@ func TestGetBootstrapKubeConfigDataFromImportSecret(t *testing.T) {
 			},
 			wantErr: false,
 			want: &wantData{
-				serverURL:   "https://my-dns-name.com:6443",
-				useInsecure: false,
-				certData:    certData2,
-				token:       "mock-token",
+				serverURL: "https://my-dns-name.com:6443",
+				certData:  certData2,
+				token:     "mock-token",
 			},
 		},
 		{
 			name:       "all fileds are valid, failed to get the ca from ocp, fallback to the kube-root-ca.crt configmap from the pod namespace.",
-			clientObjs: []client.Object{testInfraConfigDNS, apiserverConfig},
+			clientObjs: []client.Object{testInfraConfigDNS, apiserverConfigWithCustomCA},
 			runtimeObjs: []runtime.Object{cm,
 				mockImportSecret(t, time.Now().Add(8640*time.Hour),
 					"https://my-dns-name.com:6443",
@@ -189,34 +255,53 @@ func TestGetBootstrapKubeConfigDataFromImportSecret(t *testing.T) {
 			},
 			wantErr: false,
 			want: &wantData{
-				serverURL:   "https://my-dns-name.com:6443",
-				useInsecure: false,
-				certData:    certData1,
-				token:       "mock-token",
+				serverURL: "https://my-dns-name.com:6443",
+				certData:  certData1,
+				token:     "mock-token",
 			},
 		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Logf("Test name: %s", tt.name)
 
-			fakeKubeClinet := kubefake.NewSimpleClientset(tt.runtimeObjs...)
+			fakeKubeClient := kubefake.NewSimpleClientset(tt.runtimeObjs...)
+
+			fakeKubeClient.PrependReactor(
+				"create",
+				"serviceaccounts/token",
+				func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true,
+						&authv1.TokenRequest{
+							Status: authv1.TokenRequestStatus{Token: "fake-token", ExpirationTimestamp: metav1.Now()},
+						}, nil
+				},
+			)
 
 			clientHolder := &helpers.ClientHolder{
 				RuntimeClient: fake.NewClientBuilder().WithScheme(testscheme).
 					WithObjects(tt.clientObjs...).
 					WithStatusSubresource(tt.clientObjs...).
 					Build(),
-				KubeClient: fakeKubeClinet,
+				KubeClient: fakeKubeClient,
 			}
 
-			kubeconfigData, _, _, err := getBootstrapKubeConfigDataFromImportSecret(context.Background(), clientHolder, "testcluster", tt.klusterletConfig) // cluster.Name = testcluster
-			if (err != nil) != tt.wantErr {
-				t.Errorf("getBootstrapKubeConfigDataFromImportSecret() error = %v, wantErr %v", err, tt.wantErr)
-				return
+			cluster := &clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testcluster",
+				},
 			}
+
+			if tt.selfManaged {
+				cluster.Labels = map[string]string{
+					constants.SelfManagedLabel: "true",
+				}
+			}
+
+			kubeconfigData, _, _, err := buildBootstrapKubeconfigData(context.Background(), clientHolder, cluster, tt.klusterletConfig) // cluster.Name = testcluster
 			if err != nil {
-				// it's safe to return here, because the last step, if err is not nil, and we don't expect err, it will fail the test
+				t.Errorf("buildBootstrapKubeconfigData() error = %v", err)
 				return
 			}
 
@@ -224,49 +309,44 @@ func TestGetBootstrapKubeConfigDataFromImportSecret(t *testing.T) {
 				if kubeconfigData == nil {
 					return
 				} else {
-					t.Errorf("getBootstrapKubeConfigDataFromImportSecret() returns wrong data. want nil, got %v", kubeconfigData)
+					t.Errorf("buildBootstrapKubeconfigData() returns wrong data. want nil, got %v", kubeconfigData)
 					return
 				}
 			}
 			if tt.want != nil && kubeconfigData == nil {
-				t.Errorf("getBootstrapKubeConfigDataFromImportSecret() returns wrong data. want %v, got nil", tt.want)
+				t.Errorf("buildBootstrapKubeconfigData() returns wrong data. want %v, got nil", tt.want)
 				return
 			}
 
 			bootstrapConfig := &clientcmdapi.Config{}
 			if err := runtime.DecodeInto(clientcmdlatest.Codec, kubeconfigData, bootstrapConfig); err != nil {
-				t.Errorf("createKubeconfigData() failed to decode return data")
+				t.Errorf("buildBootstrapKubeconfigData() failed to decode return data")
 				return
 			}
-			clusterConfig, ok := bootstrapConfig.Clusters["default-cluster"]
+
+			configContext := bootstrapConfig.Contexts[bootstrapConfig.CurrentContext]
+			clusterConfig, ok := bootstrapConfig.Clusters[configContext.Cluster]
 			if !ok {
-				t.Errorf("createKubeconfigData() failed to get default-cluster")
+				t.Errorf("buildBootstrapKubeconfigData() failed to get %s", configContext.Cluster)
 				return
 			}
 			authInfo, ok := bootstrapConfig.AuthInfos["default-auth"]
 			if !ok {
-				t.Errorf("createKubeconfigData() failed to get default-auth")
+				t.Errorf("buildBootstrapKubeconfigData() failed to get default-auth")
 				return
 			}
 
 			if clusterConfig.Server != tt.want.serverURL {
 				t.Errorf(
-					"createKubeconfigData() returns wrong server. want %v, got %v",
+					"buildBootstrapKubeconfigData() returns wrong server. want %v, got %v",
 					tt.want.serverURL,
 					clusterConfig.Server,
-				)
-			}
-			if clusterConfig.InsecureSkipTLSVerify != tt.want.useInsecure {
-				t.Errorf(
-					"createKubeconfigData() returns wrong insecure. want %v, got %v",
-					tt.want.useInsecure,
-					clusterConfig.InsecureSkipTLSVerify,
 				)
 			}
 
 			if !reflect.DeepEqual(clusterConfig.CertificateAuthorityData, tt.want.certData) {
 				t.Errorf(
-					"createKubeconfigData() returns wrong cert. want %v, got %v",
+					"buildBootstrapKubeconfigData() returns wrong cert. want %v, got %v",
 					string(tt.want.certData),
 					string(clusterConfig.CertificateAuthorityData),
 				)
@@ -274,7 +354,7 @@ func TestGetBootstrapKubeConfigDataFromImportSecret(t *testing.T) {
 
 			if authInfo.Token != tt.want.token {
 				t.Errorf(
-					"createKubeconfigData() returns wrong token. want %v, got %v",
+					"buildBootstrapKubeconfigData() returns wrong token. want %v, got %v",
 					tt.want.token,
 					authInfo.Token,
 				)

--- a/pkg/controller/importconfig/importconfig_controller.go
+++ b/pkg/controller/importconfig/importconfig_controller.go
@@ -5,11 +5,8 @@ package importconfig
 
 import (
 	"context"
-	"fmt"
 
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -19,11 +16,9 @@ import (
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 
 	"github.com/stolostron/managedcluster-import-controller/pkg/bootstrap"
-	"github.com/stolostron/managedcluster-import-controller/pkg/constants"
 	"github.com/stolostron/managedcluster-import-controller/pkg/helpers"
 
 	listerklusterletconfigv1alpha1 "github.com/stolostron/cluster-lifecycle-api/client/klusterletconfig/listers/klusterletconfig/v1alpha1"
-	operatorv1 "open-cluster-management.io/api/operator/v1"
 
 	apiconstants "github.com/stolostron/cluster-lifecycle-api/constants"
 )
@@ -83,110 +78,18 @@ func (r *ReconcileImportConfig) Reconcile(ctx context.Context, request reconcile
 		return reconcile.Result{}, err
 	}
 
-	// get the previous bootstrap kubeconfig and expiration
-	bootstrapKubeconfigData, tokenCreation, expiration, err := getBootstrapKubeConfigDataFromImportSecret(ctx,
-		r.clientHolder, managedCluster.Name, mergedKlusterletConfig)
+	// build the bootstrap kubeconfig
+	bootstrapKubeconfigData, tokenCreation, tokenExpiration, err := buildBootstrapKubeconfigData(ctx, r.clientHolder,
+		managedCluster, mergedKlusterletConfig)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 
-	// if bootstrapKubeconfig not exist or expired, create a new one
-	if bootstrapKubeconfigData == nil {
-		var token []byte
-
-		token, tokenCreation, expiration, err = bootstrap.GetBootstrapToken(ctx, r.clientHolder.KubeClient,
-			bootstrap.GetBootstrapSAName(managedCluster.Name),
-			managedCluster.Name, constants.DefaultSecretTokenExpirationSecond)
-		if err != nil {
-			return reconcile.Result{}, err
-		}
-
-		bootstrapKubeconfigData, err = bootstrap.CreateBootstrapKubeConfig(ctx, r.clientHolder,
-			managedCluster.Name, token, mergedKlusterletConfig)
-		if err != nil {
-			return reconcile.Result{}, err
-		}
-	}
-
-	var yamlcontent, crdsV1YAML, crdsV1beta1YAML []byte
-	var secretAnnotations map[string]string
-	switch mode {
-	case operatorv1.InstallModeDefault, operatorv1.InstallModeSingleton:
-		supportPriorityClass, err := helpers.SupportPriorityClass(managedCluster)
-		if err != nil {
-			return reconcile.Result{}, err
-		}
-		var priorityClassName string
-		if supportPriorityClass {
-			priorityClassName = constants.DefaultKlusterletPriorityClassName
-		}
-		config := bootstrap.NewKlusterletManifestsConfig(
-			mode,
-			managedCluster.Name,
-			bootstrapKubeconfigData).
-			WithManagedCluster(managedCluster).
-			WithKlusterletConfig(mergedKlusterletConfig).
-			WithPriorityClassName(priorityClassName)
-		yamlcontent, err = config.Generate(ctx, r.clientHolder)
-		if err != nil {
-			return reconcile.Result{}, err
-		}
-
-		crdsV1beta1YAML, err = config.GenerateKlusterletCRDsV1Beta1()
-		if err != nil {
-			return reconcile.Result{}, err
-		}
-
-		crdsV1YAML, err = config.GenerateKlusterletCRDsV1()
-		if err != nil {
-			return reconcile.Result{}, err
-		}
-	case operatorv1.InstallModeHosted, operatorv1.InstallModeSingletonHosted:
-		yamlcontent, err = bootstrap.NewKlusterletManifestsConfig(
-			mode,
-			managedCluster.Name,
-			bootstrapKubeconfigData).
-			WithManagedCluster(managedCluster).
-			WithImagePullSecretGenerate(false).
-			// the hosting cluster should support PriorityClass API and have
-			// already had the default PriorityClass
-			WithPriorityClassName(constants.DefaultKlusterletPriorityClassName).
-			WithKlusterletConfig(mergedKlusterletConfig).
-			Generate(ctx, r.clientHolder)
-		if err != nil {
-			return reconcile.Result{}, err
-		}
-
-		secretAnnotations = map[string]string{
-			constants.KlusterletDeployModeAnnotation: string(operatorv1.InstallModeHosted),
-		}
-	default:
-		return reconcile.Result{}, fmt.Errorf("klusterlet deploy mode %s not supportted", mode)
-	}
-
-	// generate import secret
-	importSecret := &corev1.Secret{
-		TypeMeta: metav1.TypeMeta{},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-%s", managedCluster.Name, constants.ImportSecretNameSuffix),
-			Namespace: managedCluster.Name,
-			Labels: map[string]string{
-				constants.ClusterImportSecretLabel: "",
-			},
-			Annotations: secretAnnotations,
-		},
-		Data: map[string][]byte{
-			constants.ImportSecretImportYamlKey:      yamlcontent,
-			constants.ImportSecretCRDSYamlKey:        crdsV1YAML,
-			constants.ImportSecretCRDSV1YamlKey:      crdsV1YAML,
-			constants.ImportSecretCRDSV1beta1YamlKey: crdsV1beta1YAML,
-		},
-	}
-	if len(tokenCreation) != 0 {
-		importSecret.Data[constants.ImportSecretTokenCreation] = tokenCreation
-	}
-	if len(expiration) != 0 {
-		importSecret.Data[constants.ImportSecretTokenExpiration] = expiration
+	// rebuild the import secret and save it if it is modified
+	importSecret, err := buildImportSecret(ctx, r.clientHolder, managedCluster, mode, mergedKlusterletConfig,
+		bootstrapKubeconfigData, tokenCreation, tokenExpiration)
+	if err != nil {
+		return reconcile.Result{}, err
 	}
 
 	if _, err := helpers.ApplyResources(


### PR DESCRIPTION
The related issue: https://issues.redhat.com/browse/ACM-15486