### PR TITLE
Refactor: move common functions out of csr controller, into `constants` or `helpers`.

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -186,3 +186,11 @@ const (
 const (
 	DefaultBootstrapHubKubeConfigSecretName = "bootstrap-hub-kubeconfig" // #nosec G101
 )
+
+const (
+	// CSRClusterNameLabel is the label key of the managed cluster name in the CSR
+	CSRClusterNameLabel = "open-cluster-management.io/cluster-name"
+
+	// If a managed cluster is from the agent-registration, the username of the CSR will be this
+	AgentRegistrationBootstrapUser = "system:serviceaccount:multicluster-engine:agent-registration-bootstrap"
+)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stolostron/managedcluster-import-controller/pkg/helpers"
 	"github.com/stolostron/managedcluster-import-controller/pkg/source"
 
+	certificatesv1 "k8s.io/api/certificates/v1"
 	kevents "k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
@@ -43,7 +44,10 @@ func AddToManager(ctx context.Context,
 	}{
 		{
 			csr.ControllerName,
-			func() error { return csr.Add(ctx, manager, clientHolder) },
+			func() error {
+				return csr.Add(ctx, manager, clientHolder,
+					[]func(ctx context.Context, csr *certificatesv1.CertificateSigningRequest) (bool, error){})
+			},
 		},
 		{
 			managedcluster.ControllerName,

--- a/pkg/controller/csr/csr_controller_test.go
+++ b/pkg/controller/csr/csr_controller_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/openshift/library-go/pkg/operator/events/eventstesting"
+	"github.com/stolostron/managedcluster-import-controller/pkg/constants"
 	"github.com/stolostron/managedcluster-import-controller/pkg/helpers"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 
@@ -37,7 +38,7 @@ func TestReconcileCSR_Reconcile(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: csrNameReconcile,
 			Labels: map[string]string{
-				clusterLabel: clusterName,
+				constants.CSRClusterNameLabel: clusterName,
 			},
 		},
 		Spec: certificatesv1.CertificateSigningRequestSpec{
@@ -49,7 +50,7 @@ func TestReconcileCSR_Reconcile(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: csrNameReconcile,
 			Labels: map[string]string{
-				clusterLabel: "specialCluster",
+				constants.CSRClusterNameLabel: "specialCluster",
 			},
 		},
 		Spec: certificatesv1.CertificateSigningRequestSpec{
@@ -147,7 +148,7 @@ func TestReconcileCSR_Reconcile(t *testing.T) {
 				recorder:     eventstesting.NewTestingEventRecorder(t),
 				approvalConditions: []func(ctx context.Context, csr *certificatesv1.CertificateSigningRequest) (bool, error){
 					func(ctx context.Context, csr *certificatesv1.CertificateSigningRequest) (bool, error) {
-						clusterName := getClusterName(csr)
+						clusterName := helpers.GetClusterName(csr)
 						cluster := clusterv1.ManagedCluster{}
 						err := clientHolder.RuntimeClient.Get(ctx, types.NamespacedName{Name: clusterName}, &cluster)
 						if errors.IsNotFound(err) {
@@ -159,7 +160,7 @@ func TestReconcileCSR_Reconcile(t *testing.T) {
 						return true, nil
 					},
 					func(ctx context.Context, csr *certificatesv1.CertificateSigningRequest) (bool, error) {
-						clusterName := getClusterName(csr)
+						clusterName := helpers.GetClusterName(csr)
 						if clusterName == "specialCluster" {
 							return true, nil
 						}
@@ -199,85 +200,12 @@ func TestReconcileCSR_Reconcile(t *testing.T) {
 
 }
 
-func Test_getClusterName(t *testing.T) {
-	testCSR := &certificatesv1.CertificateSigningRequest{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: csrNameReconcile,
-			Labels: map[string]string{
-				clusterLabel: clusterName,
-			},
-		},
-		Spec: certificatesv1.CertificateSigningRequestSpec{
-			Username: fmt.Sprintf(userNameSignature, clusterName, clusterName),
-		},
-	}
-
-	testCSRBadLabel := &certificatesv1.CertificateSigningRequest{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: csrNameReconcile,
-			Labels: map[string]string{
-				"badLabel": clusterName,
-			},
-		},
-		Spec: certificatesv1.CertificateSigningRequestSpec{
-			Username: fmt.Sprintf(userNameSignature, clusterName, clusterName),
-		},
-	}
-
-	testCSRNoLabel := &certificatesv1.CertificateSigningRequest{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: csrNameReconcile,
-		},
-		Spec: certificatesv1.CertificateSigningRequestSpec{
-			Username: fmt.Sprintf(userNameSignature, clusterName, clusterName),
-		},
-	}
-
-	type args struct {
-		csr *certificatesv1.CertificateSigningRequest
-	}
-	tests := []struct {
-		name            string
-		args            args
-		wantClusterName string
-	}{
-		{
-			name: "testCSR",
-			args: args{
-				csr: testCSR,
-			},
-			wantClusterName: clusterName,
-		},
-		{
-			name: "testCSRBadLabel",
-			args: args{
-				csr: testCSRBadLabel,
-			},
-			wantClusterName: "",
-		},
-		{
-			name: "testCSRNoLabel",
-			args: args{
-				csr: testCSRNoLabel,
-			},
-			wantClusterName: "",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if gotClusterName := getClusterName(tt.args.csr); gotClusterName != tt.wantClusterName {
-				t.Errorf("getClusterName() = %v, want %v", gotClusterName, tt.wantClusterName)
-			}
-		})
-	}
-}
-
 func Test_getApproval(t *testing.T) {
 	testCSRNoApproval := &certificatesv1.CertificateSigningRequest{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: csrNameReconcile,
 			Labels: map[string]string{
-				clusterLabel: clusterName,
+				constants.CSRClusterNameLabel: clusterName,
 			},
 		},
 		Spec: certificatesv1.CertificateSigningRequestSpec{
@@ -289,7 +217,7 @@ func Test_getApproval(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: csrNameReconcile,
 			Labels: map[string]string{
-				clusterLabel: clusterName,
+				constants.CSRClusterNameLabel: clusterName,
 			},
 		},
 		Spec: certificatesv1.CertificateSigningRequestSpec{
@@ -306,7 +234,7 @@ func Test_getApproval(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: csrNameReconcile,
 			Labels: map[string]string{
-				clusterLabel: clusterName,
+				constants.CSRClusterNameLabel: clusterName,
 			},
 		},
 		Spec: certificatesv1.CertificateSigningRequestSpec{
@@ -363,7 +291,7 @@ func Test_validUsername(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: csrNameReconcile,
 			Labels: map[string]string{
-				clusterLabel: clusterName,
+				constants.CSRClusterNameLabel: clusterName,
 			},
 		},
 		Spec: certificatesv1.CertificateSigningRequestSpec{
@@ -375,7 +303,7 @@ func Test_validUsername(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: csrNameReconcile,
 			Labels: map[string]string{
-				clusterLabel: clusterName,
+				constants.CSRClusterNameLabel: clusterName,
 			},
 		},
 		Spec: certificatesv1.CertificateSigningRequestSpec{
@@ -423,7 +351,7 @@ func Test_isValidUnapprovedBootstrapCSR(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: csrNameReconcile,
 			Labels: map[string]string{
-				clusterLabel: clusterName,
+				constants.CSRClusterNameLabel: clusterName,
 			},
 		},
 		Spec: certificatesv1.CertificateSigningRequestSpec{

--- a/pkg/helpers/csr.go
+++ b/pkg/helpers/csr.go
@@ -1,0 +1,15 @@
+package helpers
+
+import (
+	"github.com/stolostron/managedcluster-import-controller/pkg/constants"
+	certificatesv1 "k8s.io/api/certificates/v1"
+)
+
+func GetClusterName(csr *certificatesv1.CertificateSigningRequest) (clusterName string) {
+	for label, v := range csr.GetObjectMeta().GetLabels() {
+		if label == constants.CSRClusterNameLabel {
+			clusterName = v
+		}
+	}
+	return clusterName
+}

--- a/pkg/helpers/csr_test.go
+++ b/pkg/helpers/csr_test.go
@@ -1,0 +1,75 @@
+package helpers
+
+import (
+	"testing"
+
+	"github.com/stolostron/managedcluster-import-controller/pkg/constants"
+	certificatesv1 "k8s.io/api/certificates/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_getClusterName(t *testing.T) {
+	csrNameReconcile := "test-csr"
+	clusterName := "test-cluster"
+	testCSR := &certificatesv1.CertificateSigningRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: csrNameReconcile,
+			Labels: map[string]string{
+				constants.CSRClusterNameLabel: clusterName,
+			},
+		},
+	}
+
+	testCSRBadLabel := &certificatesv1.CertificateSigningRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: csrNameReconcile,
+			Labels: map[string]string{
+				"badLabel": clusterName,
+			},
+		},
+	}
+
+	testCSRNoLabel := &certificatesv1.CertificateSigningRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: csrNameReconcile,
+		},
+	}
+
+	type args struct {
+		csr *certificatesv1.CertificateSigningRequest
+	}
+	tests := []struct {
+		name            string
+		args            args
+		wantClusterName string
+	}{
+		{
+			name: "testCSR",
+			args: args{
+				csr: testCSR,
+			},
+			wantClusterName: clusterName,
+		},
+		{
+			name: "testCSRBadLabel",
+			args: args{
+				csr: testCSRBadLabel,
+			},
+			wantClusterName: "",
+		},
+		{
+			name: "testCSRNoLabel",
+			args: args{
+				csr: testCSRNoLabel,
+			},
+			wantClusterName: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if gotClusterName := GetClusterName(tt.args.csr); gotClusterName != tt.wantClusterName {
+				t.Errorf("getClusterName() = %v, want %v", gotClusterName, tt.wantClusterName)
+			}
+		})
+	}
+}


### PR DESCRIPTION
There are mainly **2** changes in this PR:

**First**, the `GetClusterName` is moved from `csr-controller` to `helpers` pkg, along with some const values move to `constant` pkg.

**Second**, the `Add` function added a `extraApprovalConditions` array, to allow the `csr controller` to accept and use customized approval conditions.

---

**What I want to achieve**, is in the future, we can have more approvalConditions defined and implementated in their our pkg(for example, flightctl approve stays in the `flightctl` pkg with other flight logic code),  when we add new approval condition, the `csr controller` don't need to change much.