### PR TITLE
fix e2e test issues when sno leader election enabled

### DIFF
--- a/test/e2e/autoimport_test.go
+++ b/test/e2e/autoimport_test.go
@@ -258,6 +258,7 @@ var _ = ginkgo.Describe("Importing a managed cluster with auto-import-secret", f
 		})
 		assertManagedClusterImportSecretApplied(managedClusterName)
 		assertManagedClusterAvailable(managedClusterName)
+		assertManagedClusterManifestWorksAvailable(managedClusterName)
 
 		configName := "autoimport-config"
 		testcluster := fmt.Sprintf("custom-%s", managedClusterName)
@@ -292,6 +293,8 @@ var _ = ginkgo.Describe("Importing a managed cluster with auto-import-secret", f
 		assertManagedClusterImportSecretCreated(testcluster, "other")
 		assertManagedClusterImportSecretApplied(testcluster)
 		assertManagedClusterAvailable(testcluster)
+		klusterletName := fmt.Sprintf("%s-klusterlet", testcluster)
+		assertManifestworkFinalizer(testcluster, klusterletName, "cluster.open-cluster-management.io/manifest-work-cleanup")
 
 		AssertKlusterletNamespace(testcluster, "klusterlet-local", "open-cluster-management-local")
 

--- a/test/e2e/cleanup_test.go
+++ b/test/e2e/cleanup_test.go
@@ -72,6 +72,9 @@ var _ = ginkgo.Describe("test cleanup resource after a cluster is detached", fun
 			_, err := hubWorkClient.WorkV1().ManifestWorks(localClusterName).Create(context.TODO(), manifestwork, metav1.CreateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
+			// check the work has added finalizer before detaching the cluster
+			assertManifestworkFinalizer(localClusterName, manifestwork.Name, "cluster.open-cluster-management.io/manifest-work-cleanup")
+
 			// detach the cluster
 			err = hubClusterClient.ClusterV1().ManagedClusters().Delete(context.TODO(), localClusterName, metav1.DeleteOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())

--- a/test/e2e/hostedcluster_test.go
+++ b/test/e2e/hostedcluster_test.go
@@ -79,6 +79,7 @@ var _ = ginkgo.Describe("Importing and detaching a managed cluster with hosted m
 			assertManagedClusterImportSecretCreated(managedClusterName, "other", operatorv1.InstallModeHosted)
 			assertManagedClusterImportSecretApplied(managedClusterName, operatorv1.InstallModeHosted)
 			assertManagedClusterAvailable(managedClusterName)
+			assertHostedManagedClusterManifestWorksAvailable(managedClusterName, hostingClusterName)
 			assertManagedClusterPriorityClassHosted(managedClusterName)
 		})
 	})
@@ -133,6 +134,7 @@ var _ = ginkgo.Describe("Importing and detaching a managed cluster with hosted m
 
 			assertManagedClusterImportSecretApplied(managedClusterName, operatorv1.InstallModeHosted)
 			assertManagedClusterAvailable(managedClusterName)
+			assertHostedManagedClusterManifestWorksAvailable(managedClusterName, hostingClusterName)
 			assertManagedClusterPriorityClassHosted(managedClusterName)
 		})
 
@@ -173,6 +175,7 @@ var _ = ginkgo.Describe("Importing and detaching a managed cluster with hosted m
 
 			assertManagedClusterImportSecretApplied(managedClusterName, operatorv1.InstallModeHosted)
 			assertManagedClusterAvailable(managedClusterName)
+			assertHostedManagedClusterManifestWorksAvailable(managedClusterName, hostingClusterName)
 			assertManagedClusterPriorityClassHosted(managedClusterName)
 		})
 	})
@@ -249,6 +252,7 @@ var _ = ginkgo.Describe("Importing and detaching a managed cluster with hosted m
 			assertManagedClusterImportSecretCreated(managedClusterName, "other", operatorv1.InstallModeHosted)
 			assertManagedClusterImportSecretApplied(managedClusterName, operatorv1.InstallModeHosted)
 			assertManagedClusterAvailable(managedClusterName)
+			assertHostedManagedClusterManifestWorksAvailable(managedClusterName, hostingClusterName)
 		})
 
 		ginkgo.JustAfterEach(func() {

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -104,7 +104,7 @@ func CreateHostedManagedClusterWithShortLeaseDuration(clusterClient clusterclien
 				},
 				Spec: clusterv1.ManagedClusterSpec{
 					HubAcceptsClient:     true,
-					LeaseDurationSeconds: 5,
+					LeaseDurationSeconds: 10,
 				},
 			},
 			metav1.CreateOptions{},
@@ -205,7 +205,7 @@ func CreateManagedClusterWithShortLeaseDuration(clusterClient clusterclient.Inte
 				},
 				Spec: clusterv1.ManagedClusterSpec{
 					HubAcceptsClient:     true,
-					LeaseDurationSeconds: 5,
+					LeaseDurationSeconds: 10,
 				},
 			},
 			metav1.CreateOptions{},


### PR DESCRIPTION
Ref: https://github.com/open-cluster-management-io/ocm/pull/727
https://issues.redhat.com/browse/ACM-15860 
- In `assertManagedClusterManifestWorksAvailable` and some cases, add the logic to check manifestwork finalizer, ensure the work agent starts working before each case. 
- In `CreateHostedManagedClusterWithShortLeaseDuration`, increase LeaseDurationSeconds to 10. Since the agent enables leader election, in some cases the agent might start slower than before, increasing the LeaseDurationSeconds to avoid force removal in `assertManagedClusterDeleted` in AfterEach.
- When `restartAgentPods`, check the agent leader to ensure the work agent works before the next step. 