### PR TITLE
add watch verb for capi clusters.cluster.x-k8s.io

### DIFF
--- a/deploy/base/clusterrole.yaml
+++ b/deploy/base/clusterrole.yaml
@@ -275,6 +275,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - networking.k8s.io
   resources:


### PR DESCRIPTION
fix the error logs 
`E0217 07:41:51.934808       1 reflector.go:158] "Unhandled Error" err="sigs.k8s.io/controller-runtime/pkg/cache/internal/informers.go:108: Failed to watch *v1beta1.Cluster: unknown (get clusters.cluster.x-k8s.io)"`