### PR TITLE
fix: use context in applyRepository call for flightctl resource recon…

### DIFF
--- a/pkg/controller/flightctl/flightctl.go
+++ b/pkg/controller/flightctl/flightctl.go
@@ -102,7 +102,7 @@ func (f *FlightCtlManager) StartReconcileFlightCtlResources(ctx context.Context)
 
 	// Keep reconcile the Repository resource every day to keep agent registration token fresh.
 	wait.Until(func() {
-		if err := f.applyRepository(context.TODO()); err != nil {
+		if err := f.applyRepository(ctx); err != nil {
 			f.recorder.Event("RepositoryFailed", fmt.Sprintf("Failed to reconcile Repository resources: %v", err))
 		}
 	}, 24*time.Hour, ctx.Done())


### PR DESCRIPTION
…ciliation

Updated the applyRepository method call to use the provided context instead of a new context.TODO(), ensuring proper context management during resource reconciliation.