### PR TITLE
Update Kubernetes version in run-unit-tests script to 1.30.0

### DIFF
--- a/build/run-unit-tests.sh
+++ b/build/run-unit-tests.sh
@@ -25,7 +25,7 @@ export XDG_CACHE_HOME="${cache_dir}"
 
 export KUBEBUILDER_ASSETS="${repo_dir}/_output/kubebuilder/bin"
 
-k8s_version="1.23.1"
+k8s_version="1.30.0"
 kubebuilder="kubebuilder-tools-${k8s_version}-${GOHOSTOS}-${GOHOSTARCH}.tar.gz"
 kubebuilder_path="${repo_dir}/_output/${kubebuilder}"
 


### PR DESCRIPTION
Fixes issue: the https://storage.googleapis.com/kubebuilder-tools/ doesn't contain `darwin-arm64` version for `1.23.1`, so we can't run unit-test locally.