### PR TITLE
Upgrade Go version to 1.24

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -4,35 +4,35 @@ name: Go
 
 on:
   push:
-    branches: [ main, release-*, backplane-* ]
+    branches: [main, release-*, backplane-*]
   pull_request:
-    branches: [ main, release-*, backplane-* ]
+    branches: [main, release-*, backplane-*]
 
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: '1.23'
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: "1.24"
 
-    - name: Set up kubectl
-      uses: azure/setup-kubectl@v3
-      with:
-        version: 'v1.24.0' # default is latest stable
-      id: install
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v3
+        with:
+          version: "v1.24.0" # default is latest stable
+        id: install
 
-    - name: E2E Tests
-      run: make e2e-test
+      - name: E2E Tests
+        run: make e2e-test
 
-    - if:  ${{ failure() }}
-      name: Logs after Tests Failed
-      run: kubectl -n open-cluster-management logs -l name=managedcluster-import-controller --tail=-1
+      - if: ${{ failure() }}
+        name: Logs after Tests Failed
+        run: kubectl -n open-cluster-management logs -l name=managedcluster-import-controller --tail=-1
 
-    - if: ${{ failure() }}
-      name: Setup tmate session after Tests Failed
-      uses: mxschmitt/action-tmate@v3
-      timeout-minutes: 120 # 120 minutes timeout
+      - if: ${{ failure() }}
+        name: Setup tmate session after Tests Failed
+        uses: mxschmitt/action-tmate@v3
+        timeout-minutes: 120 # 120 minutes timeout

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright Contributors to the Open Cluster Management project
 
-FROM registry.ci.openshift.org/stolostron/builder:go1.23-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.24-linux AS builder
 
 ENV REMOTE_SOURCE='.'
 ENV REMOTE_SOURCE_DIR='/remote-source'

--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -1,6 +1,6 @@
 # Copyright Contributors to the Open Cluster Management project
 
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.23 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.24 AS builder
 
 ENV REMOTE_SOURCE='.'
 ENV REMOTE_SOURCE_DIR='/remote-source'

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/managedcluster-import-controller
 
-go 1.23.6
+go 1.24
 
 // TODO: @xuezhaojun need to switch to the official flightctl lib once it's ready.
 replace github.com/flightctl/flightctl/lib => github.com/xuezhaojun/flightctl/lib v0.0.0-20241125124411-7eec33f53a61


### PR DESCRIPTION
This PR upgrades the Go version to 1.24.

Changes include:
- Updated go.mod to use Go 1.24
- Updated Dockerfiles to use Go 1.24 builder images
- Updated GitHub workflow file to use Go 1.24

Verified with make build - all builds successfully with Go 1.24.