### PR TITLE
Refactor: Move createdViaOther constant to constants package

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -61,6 +61,7 @@ const (
 	CreatedViaHive       = "hive"
 	CreatedViaDiscovery  = "discovery"
 	CreatedViaHypershift = "hypershift"
+	CreatedViaOther      = "other"
 )
 
 // NOSONAR-START

--- a/pkg/controller/managedcluster/managedcluster_controller.go
+++ b/pkg/controller/managedcluster/managedcluster_controller.go
@@ -29,10 +29,6 @@ const clusterNameLabel = "name"
 
 const ClusterLabel = "cluster.open-cluster-management.io/managedCluster"
 
-const (
-	createdViaOther = "other"
-)
-
 var log = logf.Log.WithName(ControllerName)
 
 // ReconcileManagedCluster reconciles a ManagedCluster object
@@ -227,7 +223,7 @@ func (r *ReconcileManagedCluster) deleteManagedClusterAddon(
 }
 
 func ensureCreateViaAnnotation(modified *bool, cluster *clusterv1.ManagedCluster) {
-	createViaOtherAnnotation := map[string]string{constants.CreatedViaAnnotation: createdViaOther}
+	createViaOtherAnnotation := map[string]string{constants.CreatedViaAnnotation: constants.CreatedViaOther}
 	viaAnnotation, ok := cluster.Annotations[constants.CreatedViaAnnotation]
 	if !ok {
 		// no created-via annotation, set it with default annotation (other)


### PR DESCRIPTION
This PR moves the `createdViaOther` constant from managedcluster_controller.go to the constants package.

## Motivation
Improve code maintainability by centralizing related constants in a single location.

## Changes
- Add `CreatedViaOther` constant to the constants.go file with other related constants
- Remove the local `createdViaOther` constant declaration from managedcluster_controller.go
- Update the `ensureCreateViaAnnotation` function to use the constant from the constants package

## Testing
All unit tests have been run and pass successfully.