### PR TITLE
retry on kube client creation failure during auto-import

### DIFF
--- a/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
@@ -222,7 +222,7 @@ func TestReconcile(t *testing.T) {
 					},
 				},
 			},
-			expectedErr:             false,
+			expectedErr:             true,
 			expectedConditionReason: constants.ConditionReasonManagedClusterImportFailed,
 		},
 	}

--- a/pkg/helpers/autoimport.go
+++ b/pkg/helpers/autoimport.go
@@ -198,6 +198,15 @@ func (i *ImportHelper) Import(backupRestore bool, cluster *clusterv1.ManagedClus
 				), false, currentRetry, nil
 		}
 
+		if totalRetry == -1 {
+			return result,
+				NewManagedClusterImportSucceededCondition(
+					metav1.ConditionFalse,
+					constants.ConditionReasonManagedClusterImportFailed,
+					failureMessageOfKubeClientGerneration(managedClusterKubeClientSecret, err),
+				), false, currentRetry, err
+		}
+
 		return result,
 			NewManagedClusterImportSucceededCondition(
 				metav1.ConditionFalse,

--- a/pkg/helpers/autoimport_test.go
+++ b/pkg/helpers/autoimport_test.go
@@ -260,6 +260,46 @@ func TestImportHelper(t *testing.T) {
 			expectedConditionReason:  constants.ConditionReasonManagedClusterImporting,
 		},
 		{
+			name:       "retry forever with invalid auto-import kubeconfig",
+			lastRetry:  0,
+			totalRetry: -1,
+			works: []runtime.Object{
+				&workv1.ManifestWork{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-klusterlet-crds",
+						Namespace: managedClusterName,
+						Labels: map[string]string{
+							constants.KlusterletWorksLabel: "true",
+						},
+					},
+				},
+				&workv1.ManifestWork{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-klusterlet",
+						Namespace: managedClusterName,
+						Labels: map[string]string{
+							constants.KlusterletWorksLabel: "true",
+						},
+					},
+				},
+			},
+			importSecret: testinghelpers.GetImportSecret(managedClusterName),
+			autoImportSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-admin-kubeconfig",
+					Namespace: managedClusterName,
+				},
+				Data: map[string][]byte{
+					"kubeconfig": []byte("invalid-kubeconfig"),
+				},
+			},
+			generateClientHolderFunc: GenerateImportClientFromKubeConfigSecret,
+			expectedErr:              true,
+			expectedCurrentRetry:     0,
+			expectedConditionStatus:  metav1.ConditionFalse,
+			expectedConditionReason:  constants.ConditionReasonManagedClusterImportFailed,
+		},
+		{
 			name:       "retry forever",
 			lastRetry:  0,
 			totalRetry: -1,


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/ACM-18991