### PR TITLE
Refactor ensureCreateViaAnnotation to use a map for valid created-via values

### DIFF
--- a/pkg/controller/managedcluster/managedcluster_controller.go
+++ b/pkg/controller/managedcluster/managedcluster_controller.go
@@ -235,12 +235,16 @@ func ensureCreateViaAnnotation(modified *bool, cluster *clusterv1.ManagedCluster
 		return
 	}
 
-	// there is a created-via annotation and the annotation is not created by hive or hypershift, we ensue that the
-	// created-via annotation is default annotation
-	if viaAnnotation != constants.CreatedViaAI &&
-		viaAnnotation != constants.CreatedViaHive &&
-		viaAnnotation != constants.CreatedViaDiscovery &&
-		viaAnnotation != constants.CreatedViaHypershift {
+	// Define a set of valid created-via values
+	validCreatedViaValues := map[string]bool{
+		constants.CreatedViaAI:         true,
+		constants.CreatedViaHive:       true,
+		constants.CreatedViaDiscovery:  true,
+		constants.CreatedViaHypershift: true,
+	}
+
+	// If the annotation value is not in the valid set, set it to the default value (other)
+	if !validCreatedViaValues[viaAnnotation] {
 		resourcemerge.MergeMap(modified, &cluster.Annotations, createViaOtherAnnotation)
 	}
 }


### PR DESCRIPTION
The logic for checking the created-via value in the ensureCreateViaAnnotation function has been optimized by using a map to replace multiple conditional statements.

This refactoring has the following advantages:
1. The code is more concise, eliminating the need for long conditional statements.
2. It is easier to maintain; when a new CreatedVia value needs to be added, simply add an entry to the map.
3. The logic is clearer, directly expressing the intent of "using a default value if it is not in the set of valid values."

All tests have passed to ensure functionality is normal.