### PR TITLE
Add multiarch build support to Tekton pipelines

### DIFF
--- a/.tekton/managedcluster-import-controller-addon-mce-29-pull-request.yaml
+++ b/.tekton/managedcluster-import-controller-addon-mce-29-pull-request.yaml
@@ -29,6 +29,9 @@ spec:
     - name: build-platforms
       value:
         - linux/x86_64
+        - linux/arm64
+        - linux/ppc64le
+        - linux/s390x
     - name: dockerfile
       value: build/Dockerfile.rhtap
     - name: path-context
@@ -109,6 +112,9 @@ spec:
         type: string
       - default:
           - linux/x86_64
+          - linux/arm64
+          - linux/ppc64le
+          - linux/s390x
         description: List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.
         name: build-platforms
         type: array

--- a/.tekton/managedcluster-import-controller-addon-mce-29-push.yaml
+++ b/.tekton/managedcluster-import-controller-addon-mce-29-push.yaml
@@ -26,6 +26,9 @@ spec:
     - name: build-platforms
       value:
         - linux/x86_64
+        - linux/arm64
+        - linux/ppc64le
+        - linux/s390x
     - name: dockerfile
       value: build/Dockerfile.rhtap
     - name: path-context
@@ -106,6 +109,9 @@ spec:
         type: string
       - default:
           - linux/x86_64
+          - linux/arm64
+          - linux/ppc64le
+          - linux/s390x
         description: List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.
         name: build-platforms
         type: array


### PR DESCRIPTION
This PR adds multiarch build support to the Tekton pipeline configurations by adding support for multiple architectures: linux/x86_64, linux/arm64, linux/ppc64le, and linux/s390x. Changes include: - Updated build-platforms parameter in both pull request and push pipeline configurations - Modified both spec params and default values to include all supported architectures - Enables building container images for multiple platforms using the multi-platform controller