### PR TITLE
Update: ginkgo.time to 2h. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,8 +122,7 @@ e2e-test: build-image ensure-helm
 	@build/setup-ocm.sh
 	@build/setup-import-controller.sh
 	go test -c ./test/e2e -o _output/e2e.test
-	_output/e2e.test -test.v -ginkgo.v --ginkgo.label-filter="!agent-registration"
-
+	_output/e2e.test -test.v -ginkgo.v --ginkgo.label-filter="!agent-registration" --ginkgo.timeout=2h
 ## Clean e2e test
 .PHONY: clean-e2e-test
 clean-e2e-test:
@@ -136,7 +135,7 @@ e2e-test-prow: ensure-helm
 	@build/setup-ocm.sh enable-auto-approval
 	@build/setup-import-controller.sh enable-agent-registration
 	go test -c ./test/e2e -o _output/e2e.test
-	_output/e2e.test -test.v -ginkgo.v --ginkgo.label-filter="agent-registration"
+	_output/e2e.test -test.v -ginkgo.v --ginkgo.label-filter="agent-registration" --ginkgo.timeout=2h
 
 # Update vendor
 .PHONY: vendor


### PR DESCRIPTION
In the e2e log, it shows case timeout after about 30s: 
```
[TIMEDOUT] [31.622 seconds]
```

But in our case, we configured the timeout to `5 min`: 
https://github.com/stolostron/managedcluster-import-controller/blob/cc0b7c75684f0e4bf55b91cd30a2ce7071c0a156/test/e2e/e2e_suite_test.go#L643

---

Root casue:

The error is **NOT** caused by **spec timeout**, but the **whole suite timeout.** 

By default the suite timeout is **1 hour**, as our test cases add more and more, it needs more than 1 hour, so any case that happens be running at around 1 hour, will be cancelled.