### PR TITLE
Fix klusterlet 2.13 CR doesn't match 2.14 CRD in globalhub's no-operator case.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	k8s.io/component-base v0.32.1
 	k8s.io/klog/v2 v2.130.1
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738
-	open-cluster-management.io/api v0.14.1-0.20240627145512-bd6f2229b53c
+	open-cluster-management.io/api v0.14.1-0.20250708065710-54efb2e2ae7b
 	sigs.k8s.io/controller-runtime v0.19.3
 )
 

--- a/go.sum
+++ b/go.sum
@@ -643,8 +643,8 @@ k8s.io/utils v0.0.0-20210802155522-efc7438f0176/go.mod h1:jPW/WVKK9YHAvNhRxK0md/
 k8s.io/utils v0.0.0-20211116205334-6203023598ed/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 h1:M3sRQVHv7vB20Xc2ybTt7ODCeFj6JSWYFzOFnYeS6Ro=
 k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
-open-cluster-management.io/api v0.14.1-0.20240627145512-bd6f2229b53c h1:gYfgkX/U6fv2d3Ly8D6N1GM9zokORupLSgCxx791zZw=
-open-cluster-management.io/api v0.14.1-0.20240627145512-bd6f2229b53c/go.mod h1:9erZEWEn4bEqh0nIX2wA7f/s3KCuFycQdBrPrRzi0QM=
+open-cluster-management.io/api v0.14.1-0.20250708065710-54efb2e2ae7b h1:7oRx7FR4UBMS1We5FfEvlFuTJjNIhHPqhZ6Iu5xZZC4=
+open-cluster-management.io/api v0.14.1-0.20250708065710-54efb2e2ae7b/go.mod h1:ltijKJhDifrPH0csvCUmFt5lzaERv+BBfh6X3l83rT0=
 sigs.k8s.io/cluster-api v1.9.3 h1:lKWbrXzyNmJh++IcX54ZbAmnO7tZ2wKgds7WvskpiXY=
 sigs.k8s.io/cluster-api v1.9.3/go.mod h1:5iojv38PSvOd4cxqu08Un5TQmy2yBkd3+0U7R/e+msk=
 sigs.k8s.io/controller-runtime v0.19.3 h1:XO2GvC9OPftRst6xWCpTgBZO04S2cbp0Qqkj8bX1sPw=

--- a/pkg/bootstrap/render.go
+++ b/pkg/bootstrap/render.go
@@ -353,6 +353,12 @@ func (b *KlusterletManifestsConfig) Generate(ctx context.Context, clientHolder *
 				Mode:    operatorv1.FeatureGateModeTypeEnable,
 			})
 		registrationConfiguration.BootstrapKubeConfigs = b.klusterletconfig.Spec.BootstrapKubeConfigs
+
+		// Create a deep copy of LocalSecrets to avoid modifying the original klusterletconfig
+		if registrationConfiguration.BootstrapKubeConfigs.LocalSecrets != nil {
+			localSecretsCopy := *registrationConfiguration.BootstrapKubeConfigs.LocalSecrets
+			registrationConfiguration.BootstrapKubeConfigs.LocalSecrets = &localSecretsCopy
+		}
 		registrationConfiguration.BootstrapKubeConfigs.LocalSecrets.KubeConfigSecrets = append(
 			registrationConfiguration.BootstrapKubeConfigs.LocalSecrets.KubeConfigSecrets, operatorv1.KubeConfigSecret{
 				Name: constants.DefaultBootstrapHubKubeConfigSecretName + "-current-hub",

--- a/pkg/bootstrap/render_test.go
+++ b/pkg/bootstrap/render_test.go
@@ -638,7 +638,7 @@ func TestKlusterletConfigGenerate(t *testing.T) {
 				Spec: klusterletconfigv1alpha1.KlusterletConfigSpec{
 					BootstrapKubeConfigs: operatorv1.BootstrapKubeConfigs{
 						Type: operatorv1.LocalSecrets,
-						LocalSecrets: operatorv1.LocalSecretsConfig{
+						LocalSecrets: &operatorv1.LocalSecretsConfig{
 							KubeConfigSecrets: []operatorv1.KubeConfigSecret{
 								{
 									Name: "bootstrapkubeconfig-hub1",
@@ -770,7 +770,7 @@ func TestKlusterletConfigGenerate(t *testing.T) {
 				Spec: klusterletconfigv1alpha1.KlusterletConfigSpec{
 					BootstrapKubeConfigs: operatorv1.BootstrapKubeConfigs{
 						Type: operatorv1.LocalSecrets,
-						LocalSecrets: operatorv1.LocalSecretsConfig{
+						LocalSecrets: &operatorv1.LocalSecretsConfig{
 							KubeConfigSecrets: []operatorv1.KubeConfigSecret{
 								{
 									Name: "bootstrapkubeconfig-hub1",

--- a/pkg/controller/importconfig/klusterletconfighandler_test.go
+++ b/pkg/controller/importconfig/klusterletconfighandler_test.go
@@ -201,7 +201,7 @@ func TestEnqueueManagedClusterByBootstrapKubeconfigSecret(t *testing.T) {
 			Spec: klusterletconfigv1alpha1.KlusterletConfigSpec{
 				BootstrapKubeConfigs: operatorv1.BootstrapKubeConfigs{
 					Type: operatorv1.LocalSecrets,
-					LocalSecrets: operatorv1.LocalSecretsConfig{
+					LocalSecrets: &operatorv1.LocalSecretsConfig{
 						KubeConfigSecrets: []operatorv1.KubeConfigSecret{
 							{
 								Name: "test-secret1",
@@ -218,7 +218,7 @@ func TestEnqueueManagedClusterByBootstrapKubeconfigSecret(t *testing.T) {
 			Spec: klusterletconfigv1alpha1.KlusterletConfigSpec{
 				BootstrapKubeConfigs: operatorv1.BootstrapKubeConfigs{
 					Type: operatorv1.LocalSecrets,
-					LocalSecrets: operatorv1.LocalSecretsConfig{
+					LocalSecrets: &operatorv1.LocalSecretsConfig{
 						KubeConfigSecrets: []operatorv1.KubeConfigSecret{
 							{
 								Name: "test-secret2",
@@ -343,7 +343,7 @@ func TestIndexKlusterletConfigByBootstrapKubeConfigSecrets(t *testing.T) {
 		Spec: klusterletconfigv1alpha1.KlusterletConfigSpec{
 			BootstrapKubeConfigs: operatorv1.BootstrapKubeConfigs{
 				Type: operatorv1.LocalSecrets,
-				LocalSecrets: operatorv1.LocalSecretsConfig{
+				LocalSecrets: &operatorv1.LocalSecretsConfig{
 					KubeConfigSecrets: []operatorv1.KubeConfigSecret{
 						{
 							Name: "test-secret1",


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/ACM-22012

Before:

```yaml
apiVersion: [operator.open-cluster-management.io/v1](http://operator.open-cluster-management.io/v1)
kind: Klusterlet
metadata:
  name: "klusterlet-globalhub-import"
spec:
  ...
  namespace: "open-cluster-management-globalhub-import"
  registrationConfiguration:
    bootstrapKubeConfigs:
      localSecretsConfig:
        kubeConfigSecrets: null
  workConfiguration:
    {}
  nodePlacement:
```

After:

```yaml
apiVersion: operator.open-cluster-management.io/v1
kind: Klusterlet
metadata:
  name: "klusterlet-globalhub-import"
spec:
  ...
  namespace: "open-cluster-management-globalhub-import"
  registrationConfiguration:
    bootstrapKubeConfigs: {}
  workConfiguration:
    {}
  nodePlacement:
```