### PR TITLE
Remove sleep 100 from setup-kind-clusters.sh

### DIFF
--- a/build/setup-kind-clusters.sh
+++ b/build/setup-kind-clusters.sh
@@ -33,7 +33,6 @@ KIND_VERSION="v0.17.0"
 KIND="${WORK_DIR}/bin/kind"
 KUBE_VERSION="v1.29.0"
 
-sleep 100 # test only
 
 CLEAN_ARG=${1:-unclean}
 if [ "$CLEAN_ARG"x = "clean"x ]; then


### PR DESCRIPTION
This PR removes the sleep 100 line that was added as a test-only line in setup-kind-clusters.sh.

The sleep command was marked as "test only" and should not remain in the production script.