### PR TITLE
Reduce e2e test tmate timeout from 120 to 10 minutes

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -41,4 +41,4 @@ jobs:
       - if: ${{ failure() }}
         name: Setup tmate session after Tests Failed
         uses: mxschmitt/action-tmate@v3
-        timeout-minutes: 120 # 120 minutes timeout
+        timeout-minutes: 10 # 10 minutes timeout


### PR DESCRIPTION
This PR reduces the timeout for the tmate session in e2e tests from 120 minutes to 10 minutes.

The tmate session is used for debugging when e2e tests fail, and 10 minutes should be sufficient for most debugging scenarios while avoiding unnecessarily long-running workflows.

**Changes:**
- Updated `.github/workflows/e2e-tests.yml` to set `timeout-minutes: 10` instead of `timeout-minutes: 120`