### PR TITLE
Add backup label for external managed kubeconfig in local clusters

### DIFF
--- a/pkg/controller/hosted/manifests/external_managed_secret.yaml
+++ b/pkg/controller/hosted/manifests/external_managed_secret.yaml
@@ -3,6 +3,10 @@ kind: Secret
 metadata:
   name: "external-managed-kubeconfig"
   namespace: "{{ .KlusterletNamespace }}"
+  {{- if .IsLocalCluster }}
+  labels:
+    cluster.open-cluster-management.io/backup: "import-controller"
+  {{- end }}
 type: Opaque
 data:
   kubeconfig: {{ .ExternalManagedKubeconfig }}


### PR DESCRIPTION
This change adds a backup label to the external-managed-kubeconfig secret when the hosting cluster is a local cluster (has local-cluster=true label). This ensures proper backup handling for import controller secrets.

https://issues.redhat.com/browse/ACM-22972

Signed-off-by: daliu@redhat.com