### PR TITLE
Fix pathInRepo to use correct MCE version for backplane-2.6

### DIFF
--- a/.tekton/managedcluster-import-controller-addon-mce-26-pull-request.yaml
+++ b/.tekton/managedcluster-import-controller-addon-mce-26-pull-request.yaml
@@ -38,7 +38,7 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/common.yaml
+        value: pipelines/common_mce_2.6.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-managedcluster-import-controller-addon-mce-26
   workspaces:

--- a/.tekton/managedcluster-import-controller-addon-mce-26-push.yaml
+++ b/.tekton/managedcluster-import-controller-addon-mce-26-push.yaml
@@ -35,7 +35,7 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/common.yaml
+        value: pipelines/common_mce_2.6.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-managedcluster-import-controller-addon-mce-26
   workspaces:


### PR DESCRIPTION
## Summary

Fix the pathInRepo values in .tekton PipelineRun files to use `pipelines/common_mce_2.6.yaml` instead of `pipelines/common.yaml` for the backplane-2.6 branch.

## Changes

- Updated pathInRepo in managedcluster-import-controller-addon-mce-26-pull-request.yaml
- Updated pathInRepo in managedcluster-import-controller-addon-mce-26-push.yaml

## Test Plan

- Verify pipeline references point to correct version-specific pipeline file
- Ensure build processes work correctly with the updated paths

🤖 Generated with [Claude Code](https://claude.ai/code)