### PR TITLE
Update Tekton pipeline pathInRepo for backplane-2.7

### DIFF
--- a/.tekton/managedcluster-import-controller-addon-mce-27-pull-request.yaml
+++ b/.tekton/managedcluster-import-controller-addon-mce-27-pull-request.yaml
@@ -38,7 +38,7 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/common.yaml
+        value: pipelines/common_mce_2.7.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-managedcluster-import-controller-addon-mce-27
   workspaces:

--- a/.tekton/managedcluster-import-controller-addon-mce-27-push.yaml
+++ b/.tekton/managedcluster-import-controller-addon-mce-27-push.yaml
@@ -35,7 +35,7 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/common.yaml
+        value: pipelines/common_mce_2.7.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-managedcluster-import-controller-addon-mce-27
   workspaces:


### PR DESCRIPTION
## Summary

- Updated pathInRepo values in .tekton PipelineRun files to match branch version 2.7
- Changed from `pipelines/common.yaml` to `pipelines/common_mce_2.7.yaml`
- Files updated:
  - managedcluster-import-controller-addon-mce-27-pull-request.yaml
  - managedcluster-import-controller-addon-mce-27-push.yaml

## Motivation

The pathInRepo should reference the correct pipeline file that matches the branch version (2.x format). This ensures the proper pipeline configuration is used for the backplane-2.7 branch.

## Test plan

- [x] Verified the pathInRepo values are correctly updated to match 2.7 version
- [x] Confirmed the files are properly formatted and valid YAML

🤖 Generated with [Claude Code](https://claude.ai/code)