### PR TITLE
Fix .tekton PipelineRun pathInRepo for backplane-2.8 branch

### DIFF
--- a/.tekton/managedcluster-import-controller-addon-mce-28-pull-request.yaml
+++ b/.tekton/managedcluster-import-controller-addon-mce-28-pull-request.yaml
@@ -45,7 +45,7 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/common.yaml
+        value: pipelines/common_mce_2.8.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-managedcluster-import-controller-addon-mce-28
   workspaces:

--- a/.tekton/managedcluster-import-controller-addon-mce-28-push.yaml
+++ b/.tekton/managedcluster-import-controller-addon-mce-28-push.yaml
@@ -42,7 +42,7 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/common.yaml
+        value: pipelines/common_mce_2.8.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-managedcluster-import-controller-addon-mce-28
   workspaces:


### PR DESCRIPTION
## Summary

- Updated pathInRepo in .tekton PipelineRun files from `pipelines/common.yaml` to `pipelines/common_mce_2.8.yaml`
- This aligns with the backplane-2.8 branch version requirements
- Fixes both pull-request and push pipeline configurations

## Test plan

- [x] Verified pathInRepo values match branch version (2.8)
- [ ] CI pipelines should reference correct pipeline configuration

🤖 Generated with [Claude Code](https://claude.ai/code)