### PR TITLE
Fix tekton pipeline pathInRepo for backplane-2.9 branch

### DIFF
--- a/.tekton/managedcluster-import-controller-addon-mce-29-pull-request.yaml
+++ b/.tekton/managedcluster-import-controller-addon-mce-29-pull-request.yaml
@@ -44,7 +44,7 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/common.yaml
+        value: pipelines/common_mce_2.9.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-managedcluster-import-controller-addon-mce-29
   workspaces:

--- a/.tekton/managedcluster-import-controller-addon-mce-29-push.yaml
+++ b/.tekton/managedcluster-import-controller-addon-mce-29-push.yaml
@@ -41,7 +41,7 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/common.yaml
+        value: pipelines/common_mce_2.9.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-managedcluster-import-controller-addon-mce-29
   workspaces:


### PR DESCRIPTION
## Summary

- Updated pathInRepo value in tekton PipelineRun files to use correct branch-specific path
- Changed from `pipelines/common.yaml` to `pipelines/common_mce_2.9.yaml` to match backplane-2.9 branch version

## Files Changed

- `.tekton/managedcluster-import-controller-addon-mce-29-push.yaml`
- `.tekton/managedcluster-import-controller-addon-mce-29-pull-request.yaml`

## Test plan

- [x] Verified PipelineRun files contain correct pathInRepo values
- [x] Ensured pathInRepo follows pattern `pipelines/common_mce_2.x.yaml` where 2.x matches branch version

🤖 Generated with [Claude Code](https://claude.ai/code)