### PR TITLE
Add multi-platform build support and Slack notifications to Tekton pipelines

### DIFF
--- a/.tekton/managedcluster-import-controller-addon-mce-28-pull-request.yaml
+++ b/.tekton/managedcluster-import-controller-addon-mce-28-pull-request.yaml
@@ -33,6 +33,9 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/arm64
+    - linux/ppc64le
+    - linux/s390x
   - name: dockerfile
     value: build/Dockerfile.rhtap
   - name: path-context

--- a/.tekton/managedcluster-import-controller-addon-mce-28-push.yaml
+++ b/.tekton/managedcluster-import-controller-addon-mce-28-push.yaml
@@ -30,6 +30,15 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/arm64
+    - linux/ppc64le
+    - linux/s390x
+  - name: send-slack-notification
+    value: "true"
+  - name: konflux-application-name
+    value: "release-mce-28"
+  - name: slack-member-id
+    value: "U01TX25RJ3B"
   - name: dockerfile
     value: build/Dockerfile.rhtap
   - name: path-context


### PR DESCRIPTION
## Summary

This PR updates the Tekton pipeline configurations to:

- **Multi-platform build support**: Added `linux/arm64`, `linux/ppc64le`, and `linux/s390x` to the `build-platforms` parameter in both push and pull request pipelines
- **Slack notifications**: Added required Slack notification parameters (`send-slack-notification`, `konflux-application-name`, `slack-member-id`) to the push pipeline

## Changes Made

### Push Pipeline (`managedcluster-import-controller-addon-mce-28-push.yaml`)
- Extended `build-platforms` to include all required architectures
- Added `send-slack-notification: "true"`
- Added `konflux-application-name: "release-mce-28"` (matching the backplane-2.8 branch)
- Added `slack-member-id: "U01TX25RJ3B"`

### Pull Request Pipeline (`managedcluster-import-controller-addon-mce-28-pull-request.yaml`)
- Extended `build-platforms` to include all required architectures

## Testing

These changes ensure that:
- Builds will now run on multiple platforms (x86_64, arm64, ppc64le, s390x)
- Push operations will trigger Slack notifications as configured
- Pipeline configurations are standardized across the project

## Related

This update aligns with the standard Tekton pipeline configuration requirements for multi-platform builds and notification systems.