### PR TITLE
Add missing tekton pipeline parameters for backplane-2.9

### DIFF
--- a/.tekton/managedcluster-import-controller-addon-mce-29-push.yaml
+++ b/.tekton/managedcluster-import-controller-addon-mce-29-push.yaml
@@ -29,6 +29,12 @@ spec:
     - linux/arm64
     - linux/ppc64le
     - linux/s390x
+  - name: send-slack-notification
+    value: "true"
+  - name: konflux-application-name
+    value: "release-mce-29"
+  - name: slack-member-id
+    value: "U01TX25RJ3B"
   - name: dockerfile
     value: build/Dockerfile.rhtap
   - name: path-context


### PR DESCRIPTION
## Summary
- Add missing tekton pipeline parameters to the push workflow configuration
- Includes send-slack-notification, konflux-application-name, and slack-member-id parameters
- Aligns with standardized tekton pipeline requirements for release-mce-29

## Test plan
- [ ] Verify pipeline configuration is valid
- [ ] Test pipeline execution with new parameters
- [ ] Confirm slack notifications work as expected

🤖 Generated with [Claude Code](https://claude.ai/code)