### PR TITLE
Upgrade Hive APIs to master branch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/onsi/gomega v1.38.0
 	github.com/openshift/api v0.0.0-20250710004639-926605d3338b
 	github.com/openshift/assisted-service/api v0.0.0
-	github.com/openshift/hive/apis v0.0.0-20250529232658-13b99a5eb2a2
+	github.com/openshift/hive/apis v0.0.0-20250820185956-bd9fd44f4921
 	github.com/openshift/library-go v0.0.0-20250711143941-47604345e7ea // https://github.com/openshift/library-go/tree/release-4.14
 	github.com/spf13/pflag v1.0.7
 	github.com/stolostron/cluster-lifecycle-api v0.0.0-20250731061842-278b42dcc7df

--- a/go.sum
+++ b/go.sum
@@ -342,8 +342,8 @@ github.com/openshift/client-go v0.0.0-20250710075018-396b36f983ee h1:tOtrrxfDEW8
 github.com/openshift/client-go v0.0.0-20250710075018-396b36f983ee/go.mod h1:zhRiYyNMk89llof2qEuGPWPD+joQPhCRUc2IK0SB510=
 github.com/openshift/custom-resource-status v1.1.3-0.20220503160415-f2fdb4999d87 h1:cHyxR+Y8rAMT6m1jQCaYGRwikqahI0OjjUDhFNf3ySQ=
 github.com/openshift/custom-resource-status v1.1.3-0.20220503160415-f2fdb4999d87/go.mod h1:DB/Mf2oTeiAmVVX1gN+NEqweonAPY0TKUwADizj8+ZA=
-github.com/openshift/hive/apis v0.0.0-20250529232658-13b99a5eb2a2 h1:VG1I5oBdVQl31Ic5aXL/1KnqIHe1/jwJxYoPNvx73II=
-github.com/openshift/hive/apis v0.0.0-20250529232658-13b99a5eb2a2/go.mod h1:XUEuhGkTuSXP+eb0LtY3/iJTs/3Fc18CVkqMsmgN+gg=
+github.com/openshift/hive/apis v0.0.0-20250820185956-bd9fd44f4921 h1:qywdEth3yvx3ATrUq5OSlgD2sdfYKpsNQMkRcGHfR2Y=
+github.com/openshift/hive/apis v0.0.0-20250820185956-bd9fd44f4921/go.mod h1:XUEuhGkTuSXP+eb0LtY3/iJTs/3Fc18CVkqMsmgN+gg=
 github.com/openshift/hypershift/api v0.0.0-20241022184855-1fa7be0211e4 h1:hUOaw13h3naVIue2f86nBbki1lQO9C16KbKbrTn1Fzc=
 github.com/openshift/hypershift/api v0.0.0-20241022184855-1fa7be0211e4/go.mod h1:aTvlq6HevyNZ01GIaPBnnIe+HoLym3B2TIUBEol2reY=
 github.com/openshift/library-go v0.0.0-20250711143941-47604345e7ea h1:0BNis5UGo5Z7J9GtRY1nw/pt8hWxIZqvfqnqH3eV5cs=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -417,7 +417,7 @@ github.com/openshift/client-go/operator/applyconfigurations/operator/v1
 # github.com/openshift/custom-resource-status v1.1.3-0.20220503160415-f2fdb4999d87
 ## explicit; go 1.12
 github.com/openshift/custom-resource-status/conditions/v1
-# github.com/openshift/hive/apis v0.0.0-20250529232658-13b99a5eb2a2
+# github.com/openshift/hive/apis v0.0.0-20250820185956-bd9fd44f4921
 ## explicit; go 1.23.0
 github.com/openshift/hive/apis/hive/v1
 github.com/openshift/hive/apis/hive/v1/agent


### PR DESCRIPTION
## Summary
- Updated github.com/openshift/hive/apis dependency to the latest master version
- Ran go mod tidy and go mod vendor to update dependencies and vendor directory
- Verified all builds and tests pass successfully with 59.3% total coverage

## Test plan
- [x] Build check: make build passes
- [x] Test check: make test passes with 59.3% total coverage
- [x] All unit tests successful across all packages

🤖 Generated with [Claude Code](https://claude.ai/code)