### PR TITLE
Add DeepWiki badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 # managedcluster import controller
 
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/stolostron/managedcluster-import-controller)
+
 ManagedCluster import controller supports import, detach of ManagedCluster for ACM.
 
 ## Community, discussion, contribution, and support


### PR DESCRIPTION
## Summary
- Added DeepWiki documentation badge to the README
- Provides users with easy access to AI-powered documentation queries
- Badge links to https://deepwiki.com/stolostron/managedcluster-import-controller

## Test plan
- [x] Verified badge displays correctly in markdown
- [x] Confirmed link points to correct DeepWiki URL
- [x] No functional changes to code

🤖 Generated with [Claude Code](https://claude.ai/code)