### PR TITLE
Cherry-pick: Fix e2e leader election race condition and improve debugging [backplane-2.9]

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -15,7 +15,7 @@ on:
       - "docs/**"
 
 jobs:
-  test:
+  e2e-core:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -31,10 +31,263 @@ jobs:
           version: "v1.24.0" # default is latest stable
         id: install
 
-      - name: E2E Tests
-        run: OCM_VERSION=${{ github.base_ref }} make e2e-test
+      - name: E2E Tests (Core)
+        run: OCM_VERSION=${{ github.base_ref }} make e2e-test-core
 
       - if: ${{ failure() }}
-        name: Logs after Tests Failed
-        run: kubectl -n open-cluster-management logs -l name=managedcluster-import-controller --tail=-1
+        name: Collect Debug Info after Tests Failed
+        run: |
+          echo "==== Klusterlet CRs ===="
+          kubectl get klusterlets -A -o yaml || true
+
+          echo "==== Klusterlet CRD ===="
+          kubectl get crd klusterlets.operator.open-cluster-management.io -o yaml || true
+
+          echo "==== ManifestWorks ===="
+          kubectl get manifestworks -A -o yaml || true
+
+          echo "==== AppliedManifestWorks ===="
+          kubectl get appliedmanifestworks -A -o yaml || true
+
+          echo "==== ManagedClusters ===="
+          kubectl get managedclusters -A -o yaml || true
+
+          echo "==== Managed Cluster Leases ===="
+          for ns in $(kubectl get managedclusters -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
+            echo "---- Leases in namespace: $ns ----"
+            kubectl get lease -n "$ns" -o yaml || true
+          done
+
+          echo "==== Namespace open-cluster-management-agent ===="
+          kubectl get ns open-cluster-management-agent -o yaml || true
+
+          echo "==== Namespace open-cluster-management-local ===="
+          kubectl get ns open-cluster-management-local -o yaml || true
+
+          echo "==== Pods in open-cluster-management-agent ===="
+          kubectl get pods -n open-cluster-management-agent -o wide || true
+
+          echo "==== Pods in open-cluster-management-local ===="
+          kubectl get pods -n open-cluster-management-local -o wide || true
+
+          echo "==== Klusterlet Operator Pods ===="
+          kubectl get pods -n open-cluster-management -l app=klusterlet -o wide || true
+
+          echo "==== Events in open-cluster-management-agent ===="
+          kubectl get events -n open-cluster-management-agent --sort-by='.lastTimestamp' || true
+
+          echo "==== Events in open-cluster-management ===="
+          kubectl get events -n open-cluster-management --sort-by='.lastTimestamp' | tail -50 || true
+
+          echo "==== Logs from pods in open-cluster-management-agent ===="
+          for pod in $(kubectl get pods -n open-cluster-management-agent -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
+            echo "---- Logs from pod: $pod ----"
+            kubectl logs -n open-cluster-management-agent "$pod" --all-containers --tail=500 || true
+            echo "---- Previous logs from pod: $pod ----"
+            kubectl logs -n open-cluster-management-agent "$pod" --all-containers --previous --tail=500 || true
+          done
+
+          echo "==== Logs from pods in open-cluster-management-local ===="
+          for pod in $(kubectl get pods -n open-cluster-management-local -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
+            echo "---- Logs from pod: $pod ----"
+            kubectl logs -n open-cluster-management-local "$pod" --all-containers --tail=500 || true
+            echo "---- Previous logs from pod: $pod ----"
+            kubectl logs -n open-cluster-management-local "$pod" --all-containers --previous --tail=500 || true
+          done
+
+          echo "==== Klusterlet Operator Logs ===="
+          kubectl -n open-cluster-management logs -l app=klusterlet --tail=500 || true
+
+          echo "==== Import Controller Logs ===="
+          kubectl -n open-cluster-management logs -l name=managedcluster-import-controller --tail=100 || true
+
+      - if: ${{ failure() }}
+        name: Setup tmate session for debugging
+        uses: mxschmitt/action-tmate@v3
+        timeout-minutes: 30
+
+  e2e-misc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v4
+        with:
+          version: "v1.24.0" # default is latest stable
+        id: install
+
+      - name: E2E Tests (Misc)
+        run: OCM_VERSION=${{ github.base_ref }} make e2e-test-misc
+
+      - if: ${{ failure() }}
+        name: Collect Debug Info after Tests Failed
+        run: |
+          echo "==== Klusterlet CRs ===="
+          kubectl get klusterlets -A -o yaml || true
+
+          echo "==== Klusterlet CRD ===="
+          kubectl get crd klusterlets.operator.open-cluster-management.io -o yaml || true
+
+          echo "==== ManifestWorks ===="
+          kubectl get manifestworks -A -o yaml || true
+
+          echo "==== AppliedManifestWorks ===="
+          kubectl get appliedmanifestworks -A -o yaml || true
+
+          echo "==== ManagedClusters ===="
+          kubectl get managedclusters -A -o yaml || true
+
+          echo "==== Managed Cluster Leases ===="
+          for ns in $(kubectl get managedclusters -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
+            echo "---- Leases in namespace: $ns ----"
+            kubectl get lease -n "$ns" -o yaml || true
+          done
+
+          echo "==== Namespace open-cluster-management-agent ===="
+          kubectl get ns open-cluster-management-agent -o yaml || true
+
+          echo "==== Namespace open-cluster-management-local ===="
+          kubectl get ns open-cluster-management-local -o yaml || true
+
+          echo "==== Pods in open-cluster-management-agent ===="
+          kubectl get pods -n open-cluster-management-agent -o wide || true
+
+          echo "==== Pods in open-cluster-management-local ===="
+          kubectl get pods -n open-cluster-management-local -o wide || true
+
+          echo "==== Klusterlet Operator Pods ===="
+          kubectl get pods -n open-cluster-management -l app=klusterlet -o wide || true
+
+          echo "==== Events in open-cluster-management-agent ===="
+          kubectl get events -n open-cluster-management-agent --sort-by='.lastTimestamp' || true
+
+          echo "==== Events in open-cluster-management ===="
+          kubectl get events -n open-cluster-management --sort-by='.lastTimestamp' | tail -50 || true
+
+          echo "==== Logs from pods in open-cluster-management-agent ===="
+          for pod in $(kubectl get pods -n open-cluster-management-agent -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
+            echo "---- Logs from pod: $pod ----"
+            kubectl logs -n open-cluster-management-agent "$pod" --all-containers --tail=500 || true
+            echo "---- Previous logs from pod: $pod ----"
+            kubectl logs -n open-cluster-management-agent "$pod" --all-containers --previous --tail=500 || true
+          done
+
+          echo "==== Logs from pods in open-cluster-management-local ===="
+          for pod in $(kubectl get pods -n open-cluster-management-local -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
+            echo "---- Logs from pod: $pod ----"
+            kubectl logs -n open-cluster-management-local "$pod" --all-containers --tail=500 || true
+            echo "---- Previous logs from pod: $pod ----"
+            kubectl logs -n open-cluster-management-local "$pod" --all-containers --previous --tail=500 || true
+          done
+
+          echo "==== Klusterlet Operator Logs ===="
+          kubectl -n open-cluster-management logs -l app=klusterlet --tail=500 || true
+
+          echo "==== Import Controller Logs ===="
+          kubectl -n open-cluster-management logs -l name=managedcluster-import-controller --tail=100 || true
+
+      - if: ${{ failure() }}
+        name: Setup tmate session for debugging
+        uses: mxschmitt/action-tmate@v3
+        timeout-minutes: 30
+
+  e2e-hosted:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v4
+        with:
+          version: "v1.24.0" # default is latest stable
+        id: install
+
+      - name: E2E Tests (Hosted)
+        run: OCM_VERSION=${{ github.base_ref }} make e2e-test-hosted
+
+      - if: ${{ failure() }}
+        name: Collect Debug Info after Tests Failed
+        run: |
+          echo "==== Klusterlet CRs ===="
+          kubectl get klusterlets -A -o yaml || true
+
+          echo "==== Klusterlet CRD ===="
+          kubectl get crd klusterlets.operator.open-cluster-management.io -o yaml || true
+
+          echo "==== ManifestWorks ===="
+          kubectl get manifestworks -A -o yaml || true
+
+          echo "==== AppliedManifestWorks ===="
+          kubectl get appliedmanifestworks -A -o yaml || true
+
+          echo "==== ManagedClusters ===="
+          kubectl get managedclusters -A -o yaml || true
+
+          echo "==== Managed Cluster Leases ===="
+          for ns in $(kubectl get managedclusters -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
+            echo "---- Leases in namespace: $ns ----"
+            kubectl get lease -n "$ns" -o yaml || true
+          done
+
+          echo "==== Namespace open-cluster-management-agent ===="
+          kubectl get ns open-cluster-management-agent -o yaml || true
+
+          echo "==== Namespace open-cluster-management-local ===="
+          kubectl get ns open-cluster-management-local -o yaml || true
+
+          echo "==== Pods in open-cluster-management-agent ===="
+          kubectl get pods -n open-cluster-management-agent -o wide || true
+
+          echo "==== Pods in open-cluster-management-local ===="
+          kubectl get pods -n open-cluster-management-local -o wide || true
+
+          echo "==== Klusterlet Operator Pods ===="
+          kubectl get pods -n open-cluster-management -l app=klusterlet -o wide || true
+
+          echo "==== Hosted Klusterlet Namespaces ===="
+          kubectl get ns -o name | grep klusterlet- || true
+
+          echo "==== Events in open-cluster-management-agent ===="
+          kubectl get events -n open-cluster-management-agent --sort-by='.lastTimestamp' || true
+
+          echo "==== Events in open-cluster-management ===="
+          kubectl get events -n open-cluster-management --sort-by='.lastTimestamp' | tail -50 || true
+
+          echo "==== Logs from pods in open-cluster-management-agent ===="
+          for pod in $(kubectl get pods -n open-cluster-management-agent -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
+            echo "---- Logs from pod: $pod ----"
+            kubectl logs -n open-cluster-management-agent "$pod" --all-containers --tail=500 || true
+            echo "---- Previous logs from pod: $pod ----"
+            kubectl logs -n open-cluster-management-agent "$pod" --all-containers --previous --tail=500 || true
+          done
+
+          echo "==== Logs from pods in open-cluster-management-local ===="
+          for pod in $(kubectl get pods -n open-cluster-management-local -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
+            echo "---- Logs from pod: $pod ----"
+            kubectl logs -n open-cluster-management-local "$pod" --all-containers --tail=500 || true
+            echo "---- Previous logs from pod: $pod ----"
+            kubectl logs -n open-cluster-management-local "$pod" --all-containers --previous --tail=500 || true
+          done
+
+          echo "==== Klusterlet Operator Logs ===="
+          kubectl -n open-cluster-management logs -l app=klusterlet --tail=500 || true
+
+          echo "==== Import Controller Logs ===="
+          kubectl -n open-cluster-management logs -l name=managedcluster-import-controller --tail=100 || true
+
+      - if: ${{ failure() }}
+        name: Setup tmate session for debugging
+        uses: mxschmitt/action-tmate@v3
+        timeout-minutes: 30
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -1,0 +1,94 @@
+# E2E Test Authoring Guidelines
+
+## Rule: Assert Leader Election After Any klusterlet-agent Rollout
+
+**Any test step that triggers a klusterlet-agent deployment rollout MUST ensure
+the agent completes leader election before proceeding to steps that depend on the
+agent being functional (e.g., deleting a ManagedCluster).**
+
+### Root cause: initial import always triggers a rolling update
+
+The import controller creates the klusterlet deployment, then updates it ~4
+seconds later when the CSR is approved and the bootstrap token is generated. This
+second reconciliation changes the deployment spec, triggering a rolling update.
+The old pod may have set `ManagedClusterConditionAvailable=True` before being
+terminated, giving a false sense of readiness while the new pod is still
+performing leader election.
+
+### Why this matters
+
+When klusterlet-agent rolls out, the new pod must complete leader election before
+it can function. If subsequent test steps proceed before leader election
+completes, the following race condition can occur:
+
+1. A rollout starts a new klusterlet-agent pod.
+2. The old pod is terminated; the new pod begins leader election.
+3. The test proceeds (e.g., deletes `ManagedCluster`) while the new pod is still
+   waiting for the leader lease.
+4. `orphanCleanup()` force-deletes ManifestWorks **and** the `workRoleBinding`
+   (hub RBAC for the work agent).
+5. The new work agent acquires leadership but gets HTTP 403 when listing
+   ManifestWorks because hub RBAC has been removed.
+6. `AppliedManifestWork` finalizer blocks `Klusterlet` CR deletion, which blocks
+   `open-cluster-management-agent` namespace deletion, causing test timeout.
+
+### Systematic protection
+
+The leader election check is embedded in three centralized helpers. Each one:
+
+1. Lists klusterlet-agent pods in `open-cluster-management-agent` namespace.
+2. **Deletes all agent pods** to force a restart — this accelerates the rollout
+   by avoiding waiting for the old pod's graceful shutdown and any
+   CrashLoopBackOff delays.
+3. **Deletes the `klusterlet-agent-lock` lease** so the new pod can immediately
+   acquire leadership without waiting for the old lease to expire.
+4. Calls `assertAgentLeaderElection()` to wait for the new pod to become leader.
+
+The check is skipped when no agent pods exist (e.g., tests without klusterlet
+deployment, or custom namespaces via KlusterletConfig NoOperator mode).
+
+**Protected helpers:**
+
+| Helper | When the check runs |
+|--------|-------------------|
+| `assertManagedClusterDeleted()` | Before deleting the ManagedCluster in AfterEach cleanup |
+| `assertManagedClusterAvailable()` | Before checking cluster availability |
+| `assertManagedClusterOffline()` | Before checking cluster offline status |
+
+### How `assertAgentLeaderElection()` works
+
+1. Lists klusterlet-agent pods and filters out Terminating pods (non-zero
+   `DeletionTimestamp`) to avoid being blocked by old pods in graceful shutdown.
+2. Waits until there is exactly one non-terminating pod.
+3. Checks that the `klusterlet-agent-lock` lease's `HolderIdentity` matches the
+   current pod name.
+4. Timeout: 180 seconds (worst-case non-graceful acquisition is ~163s).
+
+### When explicit `assertAgentLeaderElection()` is still needed
+
+The centralized checks cover most cases. Explicit calls are only needed when a
+test deletes the ManagedCluster in its **test body** (not via AfterEach), since
+`assertManagedClusterDeleted()` is not called in that path. Examples:
+
+- `cleanup_test.go` — all three test cases call `assertAgentLeaderElection()`
+  before deleting the ManagedCluster in the test body.
+- `clusterdeployment_test.go` — the "destroy" and "detach" tests call it before
+  deleting.
+
+### Other fixes in this PR
+
+- **klusterletconfig_test.go**: Add `restartAgentPods()` after reverting invalid
+  server URL to escape CrashLoopBackOff (pod may take 10+ minutes to retry).
+- **klusterletconfig_test.go**: Tolerate `NotFound` error in `restartAgentPods()`
+  when pod is already deleted by Deployment controller during rolling update.
+
+### Leader election timing reference
+
+| Parameter      | Value |
+|----------------|-------|
+| Lease duration | 137s  |
+| Renew deadline | 107s  |
+| Retry period   | 26s   |
+
+- **Graceful** (old pod releases lease): new pod acquires within ~26s.
+- **Non-graceful** (old pod terminated without releasing): up to 163s (~2m43s).

--- a/test/e2e/cleanup_test.go
+++ b/test/e2e/cleanup_test.go
@@ -95,6 +95,11 @@ var _ = ginkgo.Describe("test cleanup resource after a cluster is detached", fun
 				return len(cluster.Finalizers) > 2
 			}, 1*time.Minute, 1*time.Second).ShouldNot(gomega.BeFalse())
 
+			// Wait for leader election before deleting the ManagedCluster. The initial
+			// import always triggers a rolling update, and the new pod must be leader
+			// before cleanup can proceed correctly. See test/e2e/README.md for details.
+			assertAgentLeaderElection()
+
 			// detach the cluster
 			err = hubClusterClient.ClusterV1().ManagedClusters().Delete(context.TODO(), localClusterName, metav1.DeleteOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
@@ -198,6 +203,11 @@ var _ = ginkgo.Describe("test cleanup resource after a cluster is detached", fun
 				return len(cluster.Finalizers) > 2
 			}, 1*time.Minute, 1*time.Second).ShouldNot(gomega.BeFalse())
 
+			// Wait for leader election before deleting the ManagedCluster. The initial
+			// import always triggers a rolling update, and the new pod must be leader
+			// before cleanup can proceed correctly. See test/e2e/README.md for details.
+			assertAgentLeaderElection()
+
 			// detach the cluster
 			err = hubClusterClient.ClusterV1().ManagedClusters().Delete(context.TODO(), localClusterName, metav1.DeleteOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
@@ -264,6 +274,11 @@ var _ = ginkgo.Describe("test cleanup resource after a cluster is detached", fun
 
 		// This case will take about several minutes to wait for the cluster state to become unavailable,
 		ginkgo.It("should keep the ns when infraenv exists", func() {
+			// Wait for leader election before deleting the ManagedCluster. The initial
+			// import always triggers a rolling update, and the new pod must be leader
+			// before cleanup can proceed correctly. See test/e2e/README.md for details.
+			assertAgentLeaderElection()
+
 			managedClusterName := localClusterName
 			assertManagedClusterNamespace(managedClusterName)
 

--- a/test/e2e/clusterdeployment_test.go
+++ b/test/e2e/clusterdeployment_test.go
@@ -153,6 +153,11 @@ var _ = ginkgo.Describe("Importing a managed cluster with clusterdeployment", fu
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 				assertManagedClusterImportSecretCreated(managedClusterName, "hive")
+
+				// Wait for leader election before checking the managed cluster status.
+				// The initial import always triggers a rolling update, and the new pod must be leader
+				// before the managed cluster can become available. See test/e2e/README.md for details.
+				assertAgentLeaderElection()
 				assertManagedClusterAvailable(managedClusterName)
 			})
 
@@ -161,6 +166,11 @@ var _ = ginkgo.Describe("Importing a managed cluster with clusterdeployment", fu
 	})
 
 	ginkgo.It(fmt.Sprintf("Should destroy the managed cluster %s", managedClusterName), func() {
+		// Wait for leader election before deleting the ManagedCluster. The initial
+		// import always triggers a rolling update, and the new pod must be leader
+		// before cleanup can proceed correctly. See test/e2e/README.md for details.
+		assertAgentLeaderElection()
+
 		ginkgo.By(fmt.Sprintf("Delete the clusterdeployment %s", managedClusterName), func() {
 			err := util.DeleteClusterDeployment(hubDynamicClient, managedClusterName)
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
@@ -178,6 +188,11 @@ var _ = ginkgo.Describe("Importing a managed cluster with clusterdeployment", fu
 	})
 
 	ginkgo.It(fmt.Sprintf("Should detach the managed cluster %s", managedClusterName), func() {
+		// Wait for leader election before deleting the ManagedCluster. The initial
+		// import always triggers a rolling update, and the new pod must be leader
+		// before cleanup can proceed correctly. See test/e2e/README.md for details.
+		assertAgentLeaderElection()
+
 		ginkgo.By(fmt.Sprintf("Delete the managed cluster %s", managedClusterName), func() {
 			err := hubClusterClient.ClusterV1().ManagedClusters().Delete(context.TODO(), managedClusterName, metav1.DeleteOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -477,6 +477,21 @@ func assertHostedManagedClusterImportSecret(managedClusterName string) {
 }
 
 func assertManagedClusterDeleted(clusterName string) {
+	// Safety net: ensure klusterlet-agent has completed leader election before deleting.
+	agentPods, podErr := hubKubeClient.CoreV1().Pods("open-cluster-management-agent").List(
+		context.TODO(), metav1.ListOptions{LabelSelector: "app=klusterlet-agent"})
+	if podErr == nil && len(agentPods.Items) > 0 {
+		// Delete all agent pods to force a restart
+		for _, pod := range agentPods.Items {
+			_ = hubKubeClient.CoreV1().Pods("open-cluster-management-agent").Delete(
+				context.TODO(), pod.Name, metav1.DeleteOptions{})
+		}
+		// Delete the leader election lease so the new pod must re-elect
+		_ = hubKubeClient.CoordinationV1().Leases("open-cluster-management-agent").Delete(
+			context.TODO(), "klusterlet-agent-lock", metav1.DeleteOptions{})
+		assertAgentLeaderElection()
+	}
+
 	ginkgo.By(fmt.Sprintf("Delete the managed cluster %s", clusterName), func() {
 		err := hubClusterClient.ClusterV1().ManagedClusters().Delete(context.TODO(), clusterName, metav1.DeleteOptions{})
 		if err != nil && !errors.IsNotFound(err) {
@@ -672,6 +687,21 @@ func assertManagedClusterImportSecretNotApplied(clusterName string) {
 }
 
 func assertManagedClusterAvailable(clusterName string) {
+	// Ensure klusterlet-agent has completed leader election before checking the availability of the managed cluster.
+	agentPods, podErr := hubKubeClient.CoreV1().Pods("open-cluster-management-agent").List(
+		context.TODO(), metav1.ListOptions{LabelSelector: "app=klusterlet-agent"})
+	if podErr == nil && len(agentPods.Items) > 0 {
+		// Delete all agent pods to force a restart
+		for _, pod := range agentPods.Items {
+			_ = hubKubeClient.CoreV1().Pods("open-cluster-management-agent").Delete(
+				context.TODO(), pod.Name, metav1.DeleteOptions{})
+		}
+		// Delete the leader election lease so the new pod must re-elect
+		_ = hubKubeClient.CoordinationV1().Leases("open-cluster-management-agent").Delete(
+			context.TODO(), "klusterlet-agent-lock", metav1.DeleteOptions{})
+		assertAgentLeaderElection()
+	}
+
 	start := time.Now()
 	defer func() {
 		util.Logf("assert managed cluster %s available spending time: %.2f seconds", clusterName, time.Since(start).Seconds())
@@ -1139,6 +1169,20 @@ func hasCertificate(certs []*x509.Certificate, cert *x509.Certificate) bool {
 }
 
 func assertManagedClusterOffline(clusterName string, timeout time.Duration) {
+	agentPods, podErr := hubKubeClient.CoreV1().Pods("open-cluster-management-agent").List(
+		context.TODO(), metav1.ListOptions{LabelSelector: "app=klusterlet-agent"})
+	if podErr == nil && len(agentPods.Items) > 0 {
+		// Delete all agent pods to force a restart
+		for _, pod := range agentPods.Items {
+			_ = hubKubeClient.CoreV1().Pods("open-cluster-management-agent").Delete(
+				context.TODO(), pod.Name, metav1.DeleteOptions{})
+		}
+		// Delete the leader election lease so the new pod must re-elect
+		_ = hubKubeClient.CoordinationV1().Leases("open-cluster-management-agent").Delete(
+			context.TODO(), "klusterlet-agent-lock", metav1.DeleteOptions{})
+		assertAgentLeaderElection()
+	}
+
 	ginkgo.By(fmt.Sprintf("Managed cluster %s should be offline", clusterName), func() {
 		gomega.Eventually(func() error {
 			cluster, err := hubClusterClient.ClusterV1().ManagedClusters().Get(context.TODO(), clusterName, metav1.GetOptions{})
@@ -1198,12 +1242,38 @@ func assertManifestworkFinalizer(namespace, workName, expected string) {
 }
 
 func assertAgentLeaderElection() {
+	// Wait for any pending deployment rollout to be initiated.
+	// After import succeeds, the ManifestWork update triggers a cascade:
+	// work agent applies klusterlet spec → klusterlet operator updates deployment → rollout.
+	// This typically takes 2-5 seconds. Without this delay, the leader election
+	// check can pass with the OLD pod that is about to be replaced by the rollout.
+	time.Sleep(10 * time.Second)
+
 	start := time.Now()
+
+	namespace := "open-cluster-management-agent"
+	agentSelector := "app=klusterlet-agent"
+	leaseName := "klusterlet-agent-lock"
+
 	ginkgo.By("Check if klusterlet agent is leader", func() {
 		gomega.Eventually(func() error {
-			namespace := "open-cluster-management-agent"
-			agentSelector := "app=klusterlet-agent"
-			leaseName := "klusterlet-agent-lock"
+			// Ensure the deployment rollout is complete before checking leader election
+			deploy, err := hubKubeClient.AppsV1().Deployments(namespace).Get(
+				context.TODO(), "klusterlet-agent", metav1.GetOptions{})
+			if err != nil {
+				return fmt.Errorf("could not get klusterlet-agent deployment: %v", err)
+			}
+			if deploy.Spec.Replicas != nil {
+				if deploy.Status.UpdatedReplicas < *deploy.Spec.Replicas {
+					return fmt.Errorf("deployment rollout in progress: updatedReplicas=%d desired=%d",
+						deploy.Status.UpdatedReplicas, *deploy.Spec.Replicas)
+				}
+				if deploy.Status.AvailableReplicas < *deploy.Spec.Replicas {
+					return fmt.Errorf("deployment not fully available: availableReplicas=%d desired=%d",
+						deploy.Status.AvailableReplicas, *deploy.Spec.Replicas)
+				}
+			}
+
 			// agent pod
 			pods, err := hubKubeClient.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{
 				LabelSelector: agentSelector,
@@ -1229,5 +1299,5 @@ func assertAgentLeaderElection() {
 			return fmt.Errorf("klusterlet agent leader is still %s not %s", *lease.Spec.HolderIdentity, pods.Items[0].Name)
 		}, 180*time.Second, 1*time.Second).Should(gomega.Succeed())
 	})
-	util.Logf("spending time: %.2f seconds", time.Since(start).Seconds())
+	util.Logf("assert agent leader election spending time: %.2f seconds", time.Since(start).Seconds())
 }

--- a/test/e2e/klusterletconfig_test.go
+++ b/test/e2e/klusterletconfig_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stolostron/managedcluster-import-controller/pkg/helpers"
 	"github.com/stolostron/managedcluster-import-controller/test/e2e/util"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
 	operatorv1 "open-cluster-management.io/api/operator/v1"
@@ -390,6 +391,12 @@ var _ = Describe("Use KlusterletConfig to customize klusterlet manifests", func(
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		})
 
+		// Restart agent pods to escape CrashLoopBackOff from the invalid server URL.
+		// The invalid URL causes the agent to crash repeatedly with increasing backoff
+		// delays. Without restarting, the pod may take 10+ minutes to retry, causing
+		// assertManagedClusterAvailable to time out.
+		restartAgentPods()
+
 		By(fmt.Sprintf("Should recover the managed cluster %s", managedClusterName), func() {
 			err := util.SetImmediateImportAnnotation(hubClusterClient, managedClusterName, "")
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
@@ -602,7 +609,12 @@ func restartAgentPods(namespaces ...string) {
 		nspodsnum[ns] = len(pods.Items)
 		for _, pod := range pods.Items {
 			err = hubKubeClient.CoreV1().Pods(ns).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
-			Expect(err).ToNot(HaveOccurred())
+			// Tolerate NotFound: the pod may have already been deleted by the
+			// Deployment controller (e.g. during a rolling update) between our
+			// List and Delete calls.
+			if err != nil && !errors.IsNotFound(err) {
+				Expect(err).ToNot(HaveOccurred())
+			}
 		}
 	}
 	gomega.Eventually(func() error {


### PR DESCRIPTION
## Summary

Cherry-pick of e2e test fixes from main (squashed commit 0901ecab) to backplane-2.9.

- **Improved e2e debug logging**: Increase pod log tail from 100 to 500 lines, collect previous container logs for crash loop diagnosis
- **Fixed leader election race condition**: Force agent pod restart before leader election check
- **Added deployment rollout delay**: Wait for deployment rollout before checking leader election to avoid checking against old pods
- **Robust rollout detection**: Check that updatedReplicas and availableReplicas match desired before verifying leader election

## Test plan

- [ ] E2E core tests pass on backplane-2.9
- [ ] E2E misc tests pass on backplane-2.9
- [ ] E2E hosted tests pass on backplane-2.9

🤖 Generated with [Claude Code](https://claude.com/claude-code)