### PR TITLE
Update OWNERS reviewers and approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,14 +1,12 @@
 reviewers:
-- zhiweiyin318
-- elgnay
-- skeeey
-- qiujian16
+- dhaiducek
+- tesshuflower
+- rokej
+- mikeshng
+
 approvers:
-- zhiweiyin318
-- elgnay
-- skeeey
-- qiujian16
-# Temporary approvers for Konflux migration to facilitate release repo prow configuration updates
-# These will be removed after the migration is complete
-- xuezhaojun
-- zhujian7
+- dhaiducek
+- tesshuflower
+- rokej
+- mikeshng
+


### PR DESCRIPTION
Updates `OWNERS` so reviewers and approvers are: dhaiducek, tesshuflower, rokej, mikeshng.

Targets `backplane-2.17`. Same change as main.

Signed-off-by: Roke Jung <roke@redhat.com>

Made with [Cursor](https://cursor.com)