### PR TITLE
Update OWNERS reviewers and approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,14 +1,12 @@
 reviewers:
-- xuezhaojun
-- zhujian7
-- zhiweiyin318
-- elgnay
-- skeeey
-- qiujian16
+- dhaiducek
+- tesshuflower
+- rokej
+- mikeshng
+
 approvers:
-- xuezhaojun
-- zhujian7
-- zhiweiyin318
-- elgnay
-- skeeey
-- qiujian16
+- dhaiducek
+- tesshuflower
+- rokej
+- mikeshng
+


### PR DESCRIPTION
Updates `OWNERS` so reviewers and approvers are: dhaiducek, tesshuflower, rokej, mikeshng.

Targets `backplane-2.8`. Same change as main.

Signed-off-by: Roke Jung <roke@redhat.com>

Made with [Cursor](https://cursor.com)