### PR TITLE
ACM-34144: fix OOM on large-scale hubs

### DIFF
--- a/pkg/bootstrap/sidecar.go
+++ b/pkg/bootstrap/sidecar.go
@@ -91,9 +91,6 @@ func injectTLSProfileSyncSidecar(
 			},
 			SecurityContext: &securityContext,
 			Resources: corev1.ResourceRequirements{
-				Limits: corev1.ResourceList{
-					corev1.ResourceMemory: resource.MustParse("128Mi"),
-				},
 				Requests: corev1.ResourceList{
 					corev1.ResourceMemory: resource.MustParse("32Mi"),
 					corev1.ResourceCPU:    resource.MustParse("10m"),

--- a/pkg/bootstrap/sidecar_test.go
+++ b/pkg/bootstrap/sidecar_test.go
@@ -198,6 +198,15 @@ func TestInjectTLSProfileSyncSidecar(t *testing.T) {
 			*sidecar.SecurityContext.RunAsNonRoot != true {
 			t.Error("sidecar security context not set correctly")
 		}
+		if len(sidecar.Resources.Limits) != 0 {
+			t.Errorf("sidecar limits = %v, want none", sidecar.Resources.Limits)
+		}
+		if got := sidecar.Resources.Requests.Memory().String(); got != "32Mi" {
+			t.Errorf("sidecar memory request = %q, want 32Mi", got)
+		}
+		if got := sidecar.Resources.Requests.Cpu().String(); got != "10m" {
+			t.Errorf("sidecar cpu request = %q, want 10m", got)
+		}
 	})
 
 	t.Run("no deployment in objects", func(t *testing.T) {

--- a/pkg/tlsprofilesync/sync.go
+++ b/pkg/tlsprofilesync/sync.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -74,6 +75,15 @@ func Run(ctx context.Context) error {
 
 	mgr, err := ctrl.NewManager(cfg, manager.Options{
 		Scheme: scheme,
+		Cache: cache.Options{
+			ByObject: map[client.Object]cache.ByObject{
+				&corev1.ConfigMap{}: {
+					Namespaces: map[string]cache.Config{
+						namespace: {},
+					},
+				},
+			},
+		},
 		Metrics: metricsserver.Options{
 			BindAddress: "0", // disable metrics server for sidecar
 		},


### PR DESCRIPTION
## Summary

- Scope the tls-profile-sync controller-runtime ConfigMap cache to the sidecar namespace via `Cache.ByObject`, so informers no longer use a cluster-wide (`NamespaceAll`) ConfigMap store.
- Remove the injected `128Mi` memory limit on the `tls-profile-sync` sidecar (keep CPU/memory requests for scheduling).

Fixes [ACM-34144](https://redhat.atlassian.net/browse/ACM-34144).

Backport of the same fix as https://github.com/stolostron/managedcluster-import-controller/pull/1084 (targets `backplane-2.17`).

## Problem

On a hub with 3500+ managed SNOs, the `tls-profile-sync` sidecar in the klusterlet pod was repeatedly OOMKilled (exit 137) with a 128Mi limit. The main klusterlet container remained healthy, but the pod was Not Ready due to the failing sidecar.

## Solution

1. **Namespace-scoped ConfigMap cache** — Only cache ConfigMaps in `POD_NAMESPACE` (where `ocm-tls-profile` is written). `APIServer` remains cluster-scoped (singleton).
2. **Remove sidecar memory limit** — Avoid OOM from controller-runtime manager footprint under hub load.

## Test plan

- [x] `go test ./pkg/bootstrap/... ./pkg/tlsprofilesync/...`
- [x] Hub klusterlet pod: `tls-profile-sync` container has no memory `limits`
- [ ] Sidecar stays Running (no OOMKilled) after klusterlet manifest re-apply
- [ ] ConfigMap `ocm-tls-profile` exists in agent namespace and tracks APIServer TLS profile
- [ ] Re-verify on large-scale hub (3500+ SNOs)


Made with [Cursor](https://cursor.com)

[ACM-34144]: https://redhat.atlassian.net/browse/ACM-34144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ