### PR TITLE
Add FIPS build flags to Konflux Dockerfile

### DIFF
--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -7,7 +7,7 @@ ENV REMOTE_SOURCE_DIR='/remote-source'
 
 COPY $REMOTE_SOURCE $REMOTE_SOURCE_DIR/app/
 WORKDIR $REMOTE_SOURCE_DIR/app
-RUN BUILD_OUTPUT_DIR=${REMOTE_SOURCE_DIR}/app make build
+RUN CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime BUILD_OUTPUT_DIR=${REMOTE_SOURCE_DIR}/app make build
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 LABEL \


### PR DESCRIPTION
## Summary

- Adds `CGO_ENABLED=1` and `GOEXPERIMENT=strictfipsruntime` to the Konflux/RHTAP `build/Dockerfile.rhtap` build for the managedcluster-import-controller image.
- Addresses [HYPBLD-844](https://redhat.atlassian.net/browse/HYPBLD-844) FIPS build flag requirements.

This pull request was created by Cursor.

## Test plan

- [ ] Verify Konflux/RHTAP pipeline build succeeds for managedcluster-import-controller-addon-mce-211
- [ ] Confirm built binaries link against FIPS crypto libraries as expected


Made with [Cursor](https://cursor.com)

[HYPBLD-844]: https://redhat.atlassian.net/browse/HYPBLD-844?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ