### PR TITLE
ACM-31624: re-import clusters after hub backup restore [backplane-2.17]

### DIFF
--- a/pkg/controller/autoimport/autoimport_controller.go
+++ b/pkg/controller/autoimport/autoimport_controller.go
@@ -108,15 +108,6 @@ func (r *ReconcileAutoImport) Reconcile(ctx context.Context, request reconcile.R
 		return reconcile.Result{}, err
 	}
 	reqLogger.Info("Auto import strategy is fetched", "managedCluster", managedCluster.Name, "AutoImportStrategy", autoImportStrategy)
-	importSucceeded := meta.IsStatusConditionTrue(managedCluster.Status.Conditions, constants.ConditionManagedClusterImportSucceeded)
-	if !immediateImport && autoImportStrategy == apiconstants.AutoImportStrategyImportOnly && importSucceeded {
-		reqLogger.Info("Auto import is skipped due to the auto import strategy",
-			"managedCluster", managedCluster.Name,
-			"autoImportStrategy", autoImportStrategy,
-			"importSucceeded", importSucceeded,
-		)
-		return reconcile.Result{}, nil
-	}
 
 	autoImportSecret, err := r.informerHolder.AutoImportSecretLister.Secrets(managedClusterName).Get(constants.AutoImportSecretName)
 	if errors.IsNotFound(err) {
@@ -131,6 +122,26 @@ func (r *ReconcileAutoImport) Reconcile(ctx context.Context, request reconcile.R
 	backupRestore := false
 	if v, ok := autoImportSecret.Labels[constants.LabelAutoImportRestore]; ok && strings.EqualFold(v, "true") {
 		backupRestore = true
+	}
+
+	importSucceeded := meta.IsStatusConditionTrue(managedCluster.Status.Conditions, constants.ConditionManagedClusterImportSucceeded)
+	if !immediateImport && autoImportStrategy == apiconstants.AutoImportStrategyImportOnly && importSucceeded {
+		if backupRestore {
+			reqLogger.Info("Auto import proceeds for backup restore despite import succeeded",
+				"managedCluster", managedCluster.Name,
+				"backupRestore", backupRestore,
+				"importSucceeded", importSucceeded,
+				"autoImportStrategy", autoImportStrategy,
+			)
+		} else {
+			reqLogger.Info("Auto import is skipped due to the auto import strategy",
+				"managedCluster", managedCluster.Name,
+				"backupRestore", backupRestore,
+				"autoImportStrategy", autoImportStrategy,
+				"importSucceeded", importSucceeded,
+			)
+			return reconcile.Result{}, nil
+		}
 	}
 
 	generateClientHolderFunc, err := r.getGenerateClientHolderFuncFromAutoImportSecret(managedClusterName, autoImportSecret)

--- a/pkg/controller/autoimport/autoimport_controller_test.go
+++ b/pkg/controller/autoimport/autoimport_controller_test.go
@@ -139,6 +139,54 @@ func TestReconcile(t *testing.T) {
 			expectedConditionReason: constants.ConditionReasonManagedClusterImported,
 		},
 		{
+			name: "with ImportOnly strategy and backup restore auto-import-secret",
+			objs: []client.Object{
+				testinghelpers.NewManagedClusterBuilder(managedClusterName).
+					WithImportedCondition(true).
+					Build(),
+			},
+			works: []runtime.Object{
+				&workv1.ManifestWork{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-klusterlet-crds",
+						Namespace: managedClusterName,
+						Labels: map[string]string{
+							constants.KlusterletWorksLabel: "true",
+						},
+					},
+				},
+				&workv1.ManifestWork{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-klusterlet",
+						Namespace: managedClusterName,
+						Labels: map[string]string{
+							constants.KlusterletWorksLabel: "true",
+						},
+					},
+				},
+			},
+			secrets: []runtime.Object{
+				testinghelpers.GetImportSecret(managedClusterName),
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "auto-import-secret",
+						Namespace: managedClusterName,
+						Labels: map[string]string{
+							constants.LabelAutoImportRestore: "true",
+						},
+					},
+					Data: map[string][]byte{
+						"kubeconfig": testinghelpers.BuildKubeconfig(config),
+					},
+					Type: constants.AutoImportSecretKubeConfig,
+				},
+			},
+			autoImportStrategy:      apiconstants.AutoImportStrategyImportOnly,
+			expectedErr:             true,
+			expectedConditionStatus: metav1.ConditionFalse,
+			expectedConditionReason: constants.ConditionReasonManagedClusterImporting,
+		},
+		{
 			name: "with ImportOnly strategy and immediate-import annotation",
 			objs: []client.Object{
 				testinghelpers.NewManagedClusterBuilder(managedClusterName).


### PR DESCRIPTION
## Summary

- After hub backup/restore, Velero restores `ManagedCluster` status with `ManagedClusterImportSucceeded=True`, causing the autoimport controller to skip re-import under the default `ImportOnly` strategy
- Move the auto-import secret lookup and `restore-auto-import-secret` label check before the skip logic so backup-restore clusters are re-imported with the new hub URL
- Add unit test covering ImportOnly + already-imported + backup-restore secret scenario

Fixes [ACM-31624](https://redhat.atlassian.net/browse/ACM-31624)

Backport of #1107

## Test plan

- [x] `go test ./pkg/controller/autoimport/...`
- [ ] Restore hub with imported GKE/Azure clusters and verify they become Available


Made with [Cursor](https://cursor.com)

[ACM-31624]: https://redhat.atlassian.net/browse/ACM-31624?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ