### PR TITLE
Fix DR restore race by marking ManifestWorks ReadOnly when disable-auto-import is set

### DIFF
--- a/pkg/controller/manifestwork/manager.go
+++ b/pkg/controller/manifestwork/manager.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"strings"
 
+	apiconstants "github.com/stolostron/cluster-lifecycle-api/constants"
 	"github.com/stolostron/managedcluster-import-controller/pkg/constants"
 	"github.com/stolostron/managedcluster-import-controller/pkg/helpers"
 	"github.com/stolostron/managedcluster-import-controller/pkg/source"
@@ -73,7 +74,25 @@ func Add(ctx context.Context,
 				GenericFunc: func(e event.GenericEvent) bool { return isDefaultModeObject(e.Object) },
 				DeleteFunc:  func(e event.DeleteEvent) bool { return isDefaultModeObject(e.Object) },
 				CreateFunc:  func(e event.CreateEvent) bool { return isDefaultModeObject(e.Object) },
-				UpdateFunc:  func(e event.UpdateEvent) bool { return isDefaultModeObject(e.ObjectNew) },
+				UpdateFunc: func(e event.UpdateEvent) bool {
+					if !isDefaultModeObject(e.ObjectNew) {
+						return false
+					}
+
+					// Trigger reconciliation when disable-auto-import annotation is added or removed
+					// so that ManifestWorks can be updated with ReadOnly configs
+					oldAnnotations := e.ObjectOld.GetAnnotations()
+					newAnnotations := e.ObjectNew.GetAnnotations()
+					_, oldAutoImportDisabled := oldAnnotations[apiconstants.DisableAutoImportAnnotation]
+					_, newAutoImportDisabled := newAnnotations[apiconstants.DisableAutoImportAnnotation]
+
+					if oldAutoImportDisabled != newAutoImportDisabled {
+						// Annotation added or removed - reconcile to update ManifestWork configs
+						return true
+					}
+
+					return false
+				},
 			}),
 		).
 		WatchesRawSource(

--- a/pkg/controller/manifestwork/manifestwork_controller.go
+++ b/pkg/controller/manifestwork/manifestwork_controller.go
@@ -9,11 +9,13 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/openshift/library-go/pkg/operator/events"
+	apiconstants "github.com/stolostron/cluster-lifecycle-api/constants"
 	"github.com/stolostron/managedcluster-import-controller/pkg/constants"
 	"github.com/stolostron/managedcluster-import-controller/pkg/helpers"
 	"github.com/stolostron/managedcluster-import-controller/pkg/source"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -141,6 +143,10 @@ func createManifestWorks(
 			panic(err)
 		}
 
+		crdManifests := []workv1.Manifest{
+			{RawExtension: runtime.RawExtension{Raw: jsonData}},
+		}
+
 		crdWork := &workv1.ManifestWork{
 			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
@@ -156,10 +162,9 @@ func createManifestWorks(
 			},
 			Spec: workv1.ManifestWorkSpec{
 				Workload: workv1.ManifestsTemplate{
-					Manifests: []workv1.Manifest{
-						{RawExtension: runtime.RawExtension{Raw: jsonData}},
-					},
+					Manifests: crdManifests,
 				},
+				ManifestConfigs: buildManifestConfigs(managedCluster, crdManifests),
 			},
 		}
 
@@ -191,6 +196,7 @@ func createManifestWorks(
 			Workload: workv1.ManifestsTemplate{
 				Manifests: manifests,
 			},
+			ManifestConfigs: buildManifestConfigs(managedCluster, manifests),
 			DeleteOption: &workv1.DeleteOption{
 				PropagationPolicy: workv1.DeletePropagationPolicyTypeOrphan,
 			},
@@ -212,4 +218,45 @@ func createManifestWorks(
 	}
 
 	return works
+}
+
+// buildManifestConfigs creates ManifestConfigs for all manifests in the ManifestWork.
+// If disable-auto-import annotation is set on the ManagedCluster, all manifests are marked ReadOnly
+// to prevent work-agent from creating or updating them. This prevents the DR restore race condition
+// where work-agent (connected to backup hub) overwrites resources that the restore hub just pushed.
+func buildManifestConfigs(managedCluster *clusterv1.ManagedCluster, manifests []workv1.Manifest) []workv1.ManifestConfigOption {
+	// Check if auto-import is disabled
+	_, autoImportDisabled := managedCluster.Annotations[apiconstants.DisableAutoImportAnnotation]
+	if !autoImportDisabled {
+		// No special config needed - use default Update strategy
+		return nil
+	}
+
+	// Build ReadOnly configs for all manifests
+	configs := make([]workv1.ManifestConfigOption, 0, len(manifests))
+	for _, manifest := range manifests {
+		obj := helpers.MustCreateObject(manifest.Raw)
+		metadata, err := meta.Accessor(obj)
+		if err != nil {
+			// Skip if we can't get metadata
+			log.Error(err, "Failed to get metadata for manifest, skipping ReadOnly config")
+			continue
+		}
+
+		gvk := obj.GetObjectKind().GroupVersionKind()
+		config := workv1.ManifestConfigOption{
+			ResourceIdentifier: workv1.ResourceIdentifier{
+				Group:     gvk.Group,
+				Resource:  "", // Will be inferred by work-agent from GVK
+				Name:      metadata.GetName(),
+				Namespace: metadata.GetNamespace(),
+			},
+			UpdateStrategy: &workv1.UpdateStrategy{
+				Type: workv1.UpdateStrategyTypeReadOnly,
+			},
+		}
+		configs = append(configs, config)
+	}
+
+	return configs
 }

--- a/pkg/controller/manifestwork/manifestwork_controller_test.go
+++ b/pkg/controller/manifestwork/manifestwork_controller_test.go
@@ -156,6 +156,121 @@ func TestReconcile(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "disable-auto-import annotation set - ManifestWorks have ReadOnly configs",
+			startObjs: []client.Object{
+				&clusterv1.ManagedCluster{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "test",
+						Annotations: map[string]string{
+							"import.open-cluster-management.io/disable-auto-import": "",
+						},
+						Finalizers: []string{constants.ManifestWorkFinalizer},
+					},
+				},
+			},
+			works: []runtime.Object{},
+			secrets: []runtime.Object{
+				testinghelpers.GetImportSecret("test"),
+			},
+			request: reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name: "test",
+				},
+			},
+			validateFunc: func(t *testing.T, runtimeClient client.Client, workClient workclient.Interface) {
+				// Check klusterlet ManifestWork
+				klusterletWork, err := workClient.WorkV1().ManifestWorks("test").Get(context.TODO(), "test-klusterlet", v1.GetOptions{})
+				if err != nil {
+					t.Errorf("failed to get klusterlet ManifestWork: %v", err)
+					return
+				}
+
+				if len(klusterletWork.Spec.ManifestConfigs) == 0 {
+					t.Errorf("expected ManifestConfigs to be set, got none")
+					return
+				}
+
+				// Verify all configs have ReadOnly strategy
+				for i, config := range klusterletWork.Spec.ManifestConfigs {
+					if config.UpdateStrategy == nil {
+						t.Errorf("ManifestConfig %d has nil UpdateStrategy", i)
+						continue
+					}
+					if config.UpdateStrategy.Type != workv1.UpdateStrategyTypeReadOnly {
+						t.Errorf("ManifestConfig %d has UpdateStrategy %s, expected ReadOnly",
+							i, config.UpdateStrategy.Type)
+					}
+				}
+
+				// Check CRDs ManifestWork
+				crdsWork, err := workClient.WorkV1().ManifestWorks("test").Get(context.TODO(), "test-klusterlet-crds", v1.GetOptions{})
+				if err != nil {
+					t.Errorf("failed to get CRDs ManifestWork: %v", err)
+					return
+				}
+
+				if len(crdsWork.Spec.ManifestConfigs) == 0 {
+					t.Errorf("expected CRDs ManifestConfigs to be set, got none")
+					return
+				}
+
+				// Verify CRDs config has ReadOnly strategy
+				for i, config := range crdsWork.Spec.ManifestConfigs {
+					if config.UpdateStrategy == nil {
+						t.Errorf("CRDs ManifestConfig %d has nil UpdateStrategy", i)
+						continue
+					}
+					if config.UpdateStrategy.Type != workv1.UpdateStrategyTypeReadOnly {
+						t.Errorf("CRDs ManifestConfig %d has UpdateStrategy %s, expected ReadOnly",
+							i, config.UpdateStrategy.Type)
+					}
+				}
+			},
+		},
+		{
+			name: "no disable-auto-import annotation - ManifestWorks have no ManifestConfigs",
+			startObjs: []client.Object{
+				&clusterv1.ManagedCluster{
+					ObjectMeta: v1.ObjectMeta{
+						Name:       "test",
+						Finalizers: []string{constants.ManifestWorkFinalizer},
+					},
+				},
+			},
+			works: []runtime.Object{},
+			secrets: []runtime.Object{
+				testinghelpers.GetImportSecret("test"),
+			},
+			request: reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name: "test",
+				},
+			},
+			validateFunc: func(t *testing.T, runtimeClient client.Client, workClient workclient.Interface) {
+				// Check klusterlet ManifestWork
+				klusterletWork, err := workClient.WorkV1().ManifestWorks("test").Get(context.TODO(), "test-klusterlet", v1.GetOptions{})
+				if err != nil {
+					t.Errorf("failed to get klusterlet ManifestWork: %v", err)
+					return
+				}
+
+				if len(klusterletWork.Spec.ManifestConfigs) != 0 {
+					t.Errorf("expected no ManifestConfigs, got %d", len(klusterletWork.Spec.ManifestConfigs))
+				}
+
+				// Check CRDs ManifestWork
+				crdsWork, err := workClient.WorkV1().ManifestWorks("test").Get(context.TODO(), "test-klusterlet-crds", v1.GetOptions{})
+				if err != nil {
+					t.Errorf("failed to get CRDs ManifestWork: %v", err)
+					return
+				}
+
+				if len(crdsWork.Spec.ManifestConfigs) != 0 {
+					t.Errorf("expected no CRDs ManifestConfigs, got %d", len(crdsWork.Spec.ManifestConfigs))
+				}
+			},
+		},
 	}
 
 	for _, c := range cases {
@@ -201,3 +316,4 @@ func TestReconcile(t *testing.T) {
 		})
 	}
 }
+

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -516,6 +516,19 @@ func ManifestsEqual(newManifests, oldManifests []workv1.Manifest) bool {
 	return true
 }
 
+func ManifestConfigsEqual(newConfigs, oldConfigs []workv1.ManifestConfigOption) bool {
+	if len(newConfigs) != len(oldConfigs) {
+		return false
+	}
+
+	for i := range newConfigs {
+		if !equality.Semantic.DeepEqual(newConfigs[i], oldConfigs[i]) {
+			return false
+		}
+	}
+	return true
+}
+
 // ApplyResources apply resources, includes: serviceaccount, secret, deployment, clusterrole, clusterrolebinding,
 // crdv1, manifestwork and klusterlet
 func ApplyResources(clientHolder *ClientHolder, recorder events.Recorder,
@@ -669,6 +682,9 @@ func applyManifestWork(workClient workclient.Interface, recorder events.Recorder
 	modified := ptr.To(false)
 	resourcemerge.EnsureObjectMeta(modified, &existing.ObjectMeta, required.ObjectMeta)
 	if !ManifestsEqual(existing.Spec.Workload.Manifests, required.Spec.Workload.Manifests) {
+		*modified = true
+	}
+	if !ManifestConfigsEqual(existing.Spec.ManifestConfigs, required.Spec.ManifestConfigs) {
 		*modified = true
 	}
 

--- a/test/e2e/autoimport_test.go
+++ b/test/e2e/autoimport_test.go
@@ -94,6 +94,7 @@ var _ = ginkgo.Describe("Importing a managed cluster with auto-import-secret", g
 
 		assertManagedClusterImportSecretCreated(managedClusterName, "other")
 		assertManagedClusterManifestWorks(managedClusterName)
+		assertManagedClusterManifestWorksReadOnly(managedClusterName)
 		assertManagedClusterImportSecretNotApplied(managedClusterName)
 
 		ginkgo.By(fmt.Sprintf("Update managed cluster %s and enable auto import", managedClusterName), func() {
@@ -103,6 +104,7 @@ var _ = ginkgo.Describe("Importing a managed cluster with auto-import-secret", g
 
 		assertManagedClusterImportSecretCreated(managedClusterName, "other")
 		assertManagedClusterImportSecretApplied(managedClusterName)
+		assertManagedClusterManifestWorksNotReadOnly(managedClusterName)
 		assertManagedClusterAvailable(managedClusterName)
 		assertManagedClusterManifestWorksAvailable(managedClusterName)
 		assertManagedClusterPriorityClass(managedClusterName)

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -890,6 +890,100 @@ func assertManagedClusterManifestWorksAvailable(clusterName string) {
 	time.Sleep(10 * time.Second)
 }
 
+func assertManagedClusterManifestWorksReadOnly(clusterName string) {
+	ginkgo.By(fmt.Sprintf("Managed cluster %s manifest works should have ReadOnly configs", clusterName), func() {
+		start := time.Now()
+		gomega.Eventually(func() error {
+			klusterletCRDsName := fmt.Sprintf("%s-klusterlet-crds", clusterName)
+			klusterletName := fmt.Sprintf("%s-klusterlet", clusterName)
+			manifestWorks := hubWorkClient.WorkV1().ManifestWorks(clusterName)
+
+			// Check klusterlet-crds ManifestWork
+			klusterletCRDs, err := manifestWorks.Get(context.TODO(), klusterletCRDsName, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			if len(klusterletCRDs.Spec.ManifestConfigs) == 0 {
+				return fmt.Errorf("klusterlet-crds ManifestWork has no ManifestConfigs")
+			}
+			for i, config := range klusterletCRDs.Spec.ManifestConfigs {
+				if config.UpdateStrategy == nil {
+					return fmt.Errorf("klusterlet-crds ManifestConfig %d has nil UpdateStrategy", i)
+				}
+				if config.UpdateStrategy.Type != workv1.UpdateStrategyTypeReadOnly {
+					return fmt.Errorf("klusterlet-crds ManifestConfig %d has UpdateStrategy %s, expected ReadOnly",
+						i, config.UpdateStrategy.Type)
+				}
+			}
+
+			// Check klusterlet ManifestWork
+			klusterlet, err := manifestWorks.Get(context.TODO(), klusterletName, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			if len(klusterlet.Spec.ManifestConfigs) == 0 {
+				return fmt.Errorf("klusterlet ManifestWork has no ManifestConfigs")
+			}
+			for i, config := range klusterlet.Spec.ManifestConfigs {
+				if config.UpdateStrategy == nil {
+					return fmt.Errorf("klusterlet ManifestConfig %d has nil UpdateStrategy", i)
+				}
+				if config.UpdateStrategy.Type != workv1.UpdateStrategyTypeReadOnly {
+					return fmt.Errorf("klusterlet ManifestConfig %d has UpdateStrategy %s, expected ReadOnly",
+						i, config.UpdateStrategy.Type)
+				}
+			}
+
+			return nil
+		}, 2*time.Minute, 1*time.Second).Should(gomega.Succeed())
+		util.Logf("assert managed cluster manifestworks ReadOnly configs spending time: %.2f seconds", time.Since(start).Seconds())
+	})
+}
+
+func assertManagedClusterManifestWorksNotReadOnly(clusterName string) {
+	ginkgo.By(fmt.Sprintf("Managed cluster %s manifest works should not have ReadOnly configs", clusterName), func() {
+		start := time.Now()
+		gomega.Eventually(func() error {
+			klusterletCRDsName := fmt.Sprintf("%s-klusterlet-crds", clusterName)
+			klusterletName := fmt.Sprintf("%s-klusterlet", clusterName)
+			manifestWorks := hubWorkClient.WorkV1().ManifestWorks(clusterName)
+
+			// Check klusterlet-crds ManifestWork
+			klusterletCRDs, err := manifestWorks.Get(context.TODO(), klusterletCRDsName, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			// ManifestConfigs should be empty (nil) when annotation is not set
+			if len(klusterletCRDs.Spec.ManifestConfigs) != 0 {
+				// If configs exist, make sure they're not ReadOnly
+				for i, config := range klusterletCRDs.Spec.ManifestConfigs {
+					if config.UpdateStrategy != nil && config.UpdateStrategy.Type == workv1.UpdateStrategyTypeReadOnly {
+						return fmt.Errorf("klusterlet-crds ManifestConfig %d still has ReadOnly strategy", i)
+					}
+				}
+			}
+
+			// Check klusterlet ManifestWork
+			klusterlet, err := manifestWorks.Get(context.TODO(), klusterletName, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			// ManifestConfigs should be empty (nil) when annotation is not set
+			if len(klusterlet.Spec.ManifestConfigs) != 0 {
+				// If configs exist, make sure they're not ReadOnly
+				for i, config := range klusterlet.Spec.ManifestConfigs {
+					if config.UpdateStrategy != nil && config.UpdateStrategy.Type == workv1.UpdateStrategyTypeReadOnly {
+						return fmt.Errorf("klusterlet ManifestConfig %d still has ReadOnly strategy", i)
+					}
+				}
+			}
+
+			return nil
+		}, 2*time.Minute, 1*time.Second).Should(gomega.Succeed())
+		util.Logf("assert managed cluster manifestworks not ReadOnly spending time: %.2f seconds", time.Since(start).Seconds())
+	})
+}
+
 func assertHostedManagedClusterManifestWorksAvailable(clusterName, hostingClusterName string) {
 	assertManagedClusterFinalizer(clusterName,
 		"managedcluster-import-controller.open-cluster-management.io/manifestwork-cleanup")


### PR DESCRIPTION
## Summary

Fixes ACM-34619: Spoke cluster reconnects to backup hub instead of restore hub during DR restore (5-6% failure rate).

**Root cause:** Work-agent (on spoke) is still connected to the backup hub during DR restore. It periodically reconciles ManifestWorks every 4 minutes and overwrites the bootstrap secret that the restore hub just pushed to the spoke.  There is a manifestwork created by the managedcluster-import-controller that always exists that contains the bootsrap secret - so if this happens to be reconciled during the time window, this reset of bootstrap secret can happen (back to the original backup cluster).

**Solution:** When `disable-auto-import` annotation is set on ManagedCluster, mark all manifests in the klusterlet ManifestWorks as ReadOnly. This prevents work-agent from creating or updating resources during DR restore.

The manifestwork_controller in this repo works on 2 clusterlet manifestworks and these are the ones that will be affected by this change:

 1. `<cluster-name>-klusterlet-crds` - Contains the Klusterlet CRDs
  2. `<cluster-name>-klusterlet` - Contains the Klusterlet deployment and other resources (including the boostrap secret)

## Changes

1. **pkg/controller/manifestwork/manager.go**
   - Added watch trigger for disable-auto-import annotation changes
   - Reconciles ManifestWorks when annotation is added/removed

2. **pkg/controller/manifestwork/manifestwork_controller.go**
   - Added `buildManifestConfigs()` helper function
   - Generates ReadOnly ManifestConfigs when annotation is set
   - Applied to both klusterlet and klusterlet-crds ManifestWorks

3. **Unit tests** (manifestwork_controller_test.go)
   - Test: annotation set → ManifestWorks have ReadOnly configs
   - Test: no annotation → ManifestWorks have no ManifestConfigs

4. **E2E tests** (autoimport_test.go, e2e_suite_test.go)
   - assertManagedClusterManifestWorksReadOnly: verify ReadOnly configs exist
   - assertManagedClusterManifestWorksNotReadOnly: verify configs removed
   - Extended existing auto-import test to verify both states

## Test Plan

- [x] Unit tests pass
- [x] E2E tests compile
- [ ] E2E tests pass in CI
- [ ] Manual DR restore test with annotation set

## DR Restore Workflow

**Before restore (on backup hub):**
```bash
# Set annotation on the ManagedCluster resource on the BACKUP HUB
oc annotate managedcluster <cluster> import.open-cluster-management.io/disable-auto-import=""
```
This updates the ManifestWorks on the backup hub with ReadOnly configs. Work-agent (on spoke, connected to backup hub) receives the update via watch event.

**During restore:**
- Restore hub pushes bootstrap secret with restore hub URL to spoke
- Work-agent (still connected to backup hub) reconciles
- Work-agent sees ReadOnly configs from backup hub → does NOT overwrite bootstrap secret
- Bootstrap secret on spoke keeps restore hub URL ✅

**After spoke restarts:**
- Registration-agent uses bootstrap secret (has restore hub URL)
- Spoke connects to restore hub ✅
- Work-agent now connected to restore hub
- Backup hub decommissioned

## Related

- **Jira:** ACM-34619
- **Failure rate:** 5-6% (work-agent resync interval: 4 minutes ±50%)
- **Prevention:** ReadOnly strategy ensures work-agent only checks existence, cannot update