### PR TITLE
ACM-34995: Fix typo in ValidateKlusterletMode error message

### DIFF
--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -898,7 +898,7 @@ func IsHostedCluster(cluster *clusterv1.ManagedCluster) bool {
 
 func ValidateKlusterletMode(mode operatorv1.InstallMode) error {
 	if mode == operatorv1.InstallModeHosted && !features.DefaultMutableFeatureGate.Enabled(features.KlusterletHostedMode) {
-		return fmt.Errorf("featurn gate %s is not enabled", features.KlusterletHostedMode)
+		return fmt.Errorf("feature gate %s is not enabled", features.KlusterletHostedMode)
 	}
 	return nil
 }


### PR DESCRIPTION
## Jira
https://redhat.atlassian.net/browse/ACM-34995

## Summary
Fixed a typo in the error message returned by ValidateKlusterletMode. Changed 'featurn gate' to 'feature gate' in the error string that is displayed when hosted klusterlet mode is requested but the KlusterletHostedMode feature gate is not enabled.

## Test plan
- [x] make check
- [x] make test (build verification passed)
- [x] No functional behavior change, typo correction only

🤖 Generated via mcic-ai-helpers agent-swarm