### PR TITLE
ACM-34995: Fix typo 'featurn' in ValidateKlusterletMode error message

### DIFF
--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -898,7 +898,7 @@ func IsHostedCluster(cluster *clusterv1.ManagedCluster) bool {
 
 func ValidateKlusterletMode(mode operatorv1.InstallMode) error {
 	if mode == operatorv1.InstallModeHosted && !features.DefaultMutableFeatureGate.Enabled(features.KlusterletHostedMode) {
-		return fmt.Errorf("featurn gate %s is not enabled", features.KlusterletHostedMode)
+		return fmt.Errorf("feature gate %s is not enabled", features.KlusterletHostedMode)
 	}
 	return nil
 }


### PR DESCRIPTION
## Jira
https://redhat.atlassian.net/browse/ACM-34995

## Summary
Fixed typo in error message returned by ValidateKlusterletMode function. Changed 'featurn gate' to 'feature gate'.

This is a simple string correction with no functional behavior change. The error is returned when hosted klusterlet mode is requested but the KlusterletHostedMode feature gate is not enabled.

## Test plan
- [x] make check (copyright check passed)
- [x] make test (build verification passed)
- [x] Commit created with DCO sign-off
- [x] No functional behavior change - string only

🤖 Generated via mcic-ai-helpers agent-swarm