### PR TITLE
ACM-34995: Fix typo 'featurn' in ValidateKlusterletMode error message

### DIFF
--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -898,7 +898,7 @@ func IsHostedCluster(cluster *clusterv1.ManagedCluster) bool {
 
 func ValidateKlusterletMode(mode operatorv1.InstallMode) error {
 	if mode == operatorv1.InstallModeHosted && !features.DefaultMutableFeatureGate.Enabled(features.KlusterletHostedMode) {
-		return fmt.Errorf("featurn gate %s is not enabled", features.KlusterletHostedMode)
+		return fmt.Errorf("feature gate %s is not enabled", features.KlusterletHostedMode)
 	}
 	return nil
 }


### PR DESCRIPTION
## Jira
https://redhat.atlassian.net/browse/ACM-34995

## Summary
Corrects a typo in the `ValidateKlusterletMode` error message in `pkg/helpers/helpers.go`.
The error string said "featurn gate" instead of "feature gate" when hosted klusterlet mode
is requested but the `KlusterletHostedMode` feature gate is not enabled.

This is a text-only fix with no functional behavior change.

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./pkg/helpers/...` passes
- [x] Copyright check passes
- [x] No tests reference the old misspelled string
- [ ] `make check` — lint download timed out in CI agent (network constraint)
- [ ] `make test` — envtest download timed out in CI agent (network constraint)

🤖 Generated via mcic-ai-helpers agent-swarm