### PR TITLE
e2e test fix - Make sure e2e tests use same charts version from stolostron as the image version

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -25,12 +25,6 @@ jobs:
         with:
           go-version: "1.25"
 
-      - name: Set up kubectl
-        uses: azure/setup-kubectl@v4
-        with:
-          version: "v1.24.0" # default is latest stable
-        id: install
-
       - name: E2E Tests (Core)
         run: OCM_VERSION=${{ github.base_ref }} make e2e-test-core
 
@@ -116,12 +110,6 @@ jobs:
         with:
           go-version: "1.25"
 
-      - name: Set up kubectl
-        uses: azure/setup-kubectl@v4
-        with:
-          version: "v1.24.0" # default is latest stable
-        id: install
-
       - name: E2E Tests (Misc)
         run: OCM_VERSION=${{ github.base_ref }} make e2e-test-misc
 
@@ -206,12 +194,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "1.25"
-
-      - name: Set up kubectl
-        uses: azure/setup-kubectl@v4
-        with:
-          version: "v1.24.0" # default is latest stable
-        id: install
 
       - name: E2E Tests (Hosted)
         run: OCM_VERSION=${{ github.base_ref }} make e2e-test-hosted

--- a/build/setup-ocm.sh
+++ b/build/setup-ocm.sh
@@ -14,7 +14,7 @@ OCM_VERSION=${OCM_VERSION:-main}
 
 function wait_deployment() {
   set +e
-  for((i=0;i<30;i++));
+  for((i=0;i<60;i++));
   do
     ${KUBECTL} -n $1 get deploy $2
     if [ 0 -eq $? ]; then
@@ -24,6 +24,20 @@ function wait_deployment() {
     sleep 1
   done
   set -e
+
+  if ! ${KUBECTL} -n $1 get deploy $2 &>/dev/null; then
+    echo "####### DIAGNOSTIC: deployment $1/$2 not found after 60s #######"
+    echo "=== Pods in namespace $1 ==="
+    ${KUBECTL} -n $1 get pods -o wide || true
+    echo "=== Pod details in namespace $1 ==="
+    ${KUBECTL} -n $1 describe pods || true
+    echo "=== Cluster Manager operator logs ==="
+    ${KUBECTL} -n open-cluster-management logs -l app=cluster-manager --tail=200 || true
+    echo "=== ClusterManager CR status ==="
+    ${KUBECTL} get clustermanagers -o yaml || true
+    echo "####### END DIAGNOSTIC #######"
+    exit 1
+  fi
 }
 
 echo "###### deploy ocm"

--- a/build/setup-ocm.sh
+++ b/build/setup-ocm.sh
@@ -42,15 +42,24 @@ function wait_deployment() {
 
 echo "###### deploy ocm"
 
-go mod tidy
-go mod vendor
-
 BUILD_DIR="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 REPO_DIR="$(dirname "$BUILD_DIR")"
 HELM="${REPO_DIR}/_output/helm"
 
+#
+# We are specifically overriding images with stolostron built images, so also use the stolostron repo
+# to get the ocm helm charts for cluster-manager, ensuring the chart RBAC and operator image are
+# always from the same version.
+#
+OCM_CHART_DIR="${REPO_DIR}/_output/ocm"
+rm -rf ${OCM_CHART_DIR}
+git clone --depth 1 --branch $OCM_VERSION --filter=blob:none --sparse \
+  https://github.com/stolostron/ocm.git ${OCM_CHART_DIR}
+cd ${OCM_CHART_DIR}
+git sparse-checkout set deploy/cluster-manager/chart
+cd ${REPO_DIR}
 
-${HELM} upgrade --install cluster-manager vendor/open-cluster-management.io/ocm/deploy/cluster-manager/chart/cluster-manager \
+${HELM} upgrade --install cluster-manager ${OCM_CHART_DIR}/deploy/cluster-manager/chart/cluster-manager \
 --namespace=open-cluster-management --create-namespace --set replicaCount=1,images.registry="quay.io/stolostron",images.tag=$OCM_VERSION
 
 

--- a/build/setup-ocm.sh
+++ b/build/setup-ocm.sh
@@ -17,7 +17,7 @@ function debug_and_exit() {
   echo "=== Pods in open-cluster-management ==="
   ${KUBECTL} -n open-cluster-management get pods -o wide --ignore-not-found
   echo "=== Pod details in open-cluster-management ==="
-  ${KUBECTL} -n open-cluster-management describe pods --ignore-not-found
+  ${KUBECTL} -n open-cluster-management describe pods || true
   echo "=== Pods in open-cluster-management-hub ==="
   ${KUBECTL} -n open-cluster-management-hub get pods -o wide --ignore-not-found
   echo "=== Cluster Manager operator logs ==="

--- a/build/setup-ocm.sh
+++ b/build/setup-ocm.sh
@@ -12,32 +12,20 @@ set -o nounset
 KUBECTL=${KUBECTL:-kubectl}
 OCM_VERSION=${OCM_VERSION:-main}
 
-function wait_deployment() {
-  set +e
-  for((i=0;i<60;i++));
-  do
-    ${KUBECTL} -n $1 get deploy $2
-    if [ 0 -eq $? ]; then
-      break
-    fi
-    echo "sleep 1 second to wait deployment $1/$2 to exist: $i"
-    sleep 1
-  done
-  set -e
-
-  if ! ${KUBECTL} -n $1 get deploy $2 &>/dev/null; then
-    echo "####### DIAGNOSTIC: deployment $1/$2 not found after 60s #######"
-    echo "=== Pods in namespace $1 ==="
-    ${KUBECTL} -n $1 get pods -o wide || true
-    echo "=== Pod details in namespace $1 ==="
-    ${KUBECTL} -n $1 describe pods || true
-    echo "=== Cluster Manager operator logs ==="
-    ${KUBECTL} -n open-cluster-management logs -l app=cluster-manager --tail=200 || true
-    echo "=== ClusterManager CR status ==="
-    ${KUBECTL} get clustermanagers -o yaml || true
-    echo "####### END DIAGNOSTIC #######"
-    exit 1
-  fi
+function debug_and_exit() {
+  echo "::group::####### DIAGNOSTIC: OCM setup failure #######"
+  echo "=== Pods in open-cluster-management ==="
+  ${KUBECTL} -n open-cluster-management get pods -o wide --ignore-not-found
+  echo "=== Pod details in open-cluster-management ==="
+  ${KUBECTL} -n open-cluster-management describe pods --ignore-not-found
+  echo "=== Pods in open-cluster-management-hub ==="
+  ${KUBECTL} -n open-cluster-management-hub get pods -o wide --ignore-not-found
+  echo "=== Cluster Manager operator logs ==="
+  ${KUBECTL} -n open-cluster-management logs -l app=cluster-manager --tail=200 || true
+  echo "=== ClusterManager CR status ==="
+  ${KUBECTL} get clustermanagers -o yaml --ignore-not-found
+  echo "::endgroup::"
+  exit 1
 }
 
 echo "###### deploy ocm"
@@ -52,24 +40,22 @@ HELM="${REPO_DIR}/_output/helm"
 # always from the same version.
 #
 OCM_CHART_DIR="${REPO_DIR}/_output/ocm"
-rm -rf ${OCM_CHART_DIR}
-git clone --depth 1 --branch $OCM_VERSION --filter=blob:none --sparse \
-  https://github.com/stolostron/ocm.git ${OCM_CHART_DIR}
-cd ${OCM_CHART_DIR}
-git sparse-checkout set deploy/cluster-manager/chart
-cd ${REPO_DIR}
+rm -rf "${OCM_CHART_DIR}"
+git clone --depth 1 --branch "$OCM_VERSION" --filter=blob:none --sparse \
+  https://github.com/stolostron/ocm.git "${OCM_CHART_DIR}"
+git -C "${OCM_CHART_DIR}" sparse-checkout set deploy/cluster-manager/chart
 
-${HELM} upgrade --install cluster-manager ${OCM_CHART_DIR}/deploy/cluster-manager/chart/cluster-manager \
---namespace=open-cluster-management --create-namespace --set replicaCount=1,images.registry="quay.io/stolostron",images.tag=$OCM_VERSION
+${HELM} upgrade --install cluster-manager "${OCM_CHART_DIR}/deploy/cluster-manager/chart/cluster-manager" \
+  --namespace=open-cluster-management --create-namespace \
+  --set replicaCount=1,images.registry="quay.io/stolostron",images.tag="$OCM_VERSION"
 
+${KUBECTL} wait -n open-cluster-management --for=create deployment/cluster-manager --timeout=60s || debug_and_exit
+${KUBECTL} -n open-cluster-management rollout status deployment/cluster-manager --timeout=120s || debug_and_exit
 
-wait_deployment open-cluster-management cluster-manager
-${KUBECTL} -n open-cluster-management rollout status deploy cluster-manager --timeout=120s
-
-wait_deployment open-cluster-management-hub cluster-manager-registration-controller
-${KUBECTL} -n open-cluster-management-hub rollout status deploy cluster-manager-registration-controller --timeout=120s
-${KUBECTL} -n open-cluster-management-hub rollout status deploy cluster-manager-registration-webhook --timeout=120s
-${KUBECTL} -n open-cluster-management-hub rollout status deploy cluster-manager-work-webhook --timeout=120s
+${KUBECTL} wait -n open-cluster-management-hub --for=create deployment/cluster-manager-registration-controller --timeout=60s || debug_and_exit
+${KUBECTL} -n open-cluster-management-hub rollout status deployment/cluster-manager-registration-controller --timeout=120s || debug_and_exit
+${KUBECTL} -n open-cluster-management-hub rollout status deployment/cluster-manager-registration-webhook --timeout=120s || debug_and_exit
+${KUBECTL} -n open-cluster-management-hub rollout status deployment/cluster-manager-work-webhook --timeout=120s || debug_and_exit
 
 # scale replicas to save resources, after the hub are installed, we don't need
 # the cluster-manager and placement-controller for the e2e test


### PR DESCRIPTION
Many test failures in e2e recently, as the latest image (e2e is pulling stolostron image with `main` tag) requires some RBAC that is not available in the v1.2.1 version of the OCM charts that the e2e was using to setup cluster-manager.

- Update to use the stolostron charts at the same version (in this case it will be from `main` in stolostron/ocm) when setting up for e2e tests.

Also - did the following below to be able to see what's going on when these test fail:

Improve diagnostics when OCM setup fails during e2e test setup.

**Changes:**
- Increase `wait_deployment` timeout from 30s to 60s
- Add diagnostic output when a deployment is not found after waiting: pod list and details, cluster-manager operator logs, and ClusterManager CR status

**Context:**
All e2e tests (e2e-core, e2e-misc, e2e-hosted, ci/prow/e2e) targeting `main` have been failing since mid-June because the `quay.io/stolostron/registration-operator:main` image starts but fails to reconcile the ClusterManager CR. The current `setup-ocm.sh` provides no diagnostic output when this happens, making root cause analysis difficult. This change captures the operator pod logs and CR status on failure.

To execute skipped test pipelines write comment `/ok-to-test`.