### PR TITLE
fix: populate Resource field in ReadOnly ManifestConfigs for work-agent matching

### DIFF
--- a/pkg/controller/manifestwork/manifestwork_controller.go
+++ b/pkg/controller/manifestwork/manifestwork_controller.go
@@ -224,6 +224,25 @@ func createManifestWorks(
 // If disable-auto-import annotation is set on the ManagedCluster, all manifests are marked ReadOnly
 // to prevent work-agent from creating or updating them. This prevents the DR restore race condition
 // where work-agent (connected to backup hub) overwrites resources that the restore hub just pushed.
+//
+// The Resource field in ResourceIdentifier is populated using meta.UnsafeGuessKindToResource, which
+// applies standard English pluralization rules to the Kind name. This works correctly for all types
+// currently included in the klusterlet ManifestWorks:
+//
+//   - Namespace          -> namespaces
+//   - ClusterRole        -> clusterroles
+//   - ClusterRoleBinding -> clusterrolebindings
+//   - PriorityClass      -> priorityclasses
+//   - Secret             -> secrets
+//   - ServiceAccount     -> serviceaccounts
+//   - Deployment         -> deployments
+//   - Klusterlet         -> klusterlets
+//   - CustomResourceDefinition -> customresourcedefinitions
+//
+// If a new type is added to the klusterlet ManifestWorks, verify that
+// meta.UnsafeGuessKindToResource produces the correct plural resource name for it.
+// If it does not, the ReadOnly config for that type will silently fail to match in the
+// work-agent and the manifest will fall back to the default Update strategy.
 func buildManifestConfigs(managedCluster *clusterv1.ManagedCluster, manifests []workv1.Manifest) []workv1.ManifestConfigOption {
 	// Check if auto-import is disabled
 	_, autoImportDisabled := managedCluster.Annotations[apiconstants.DisableAutoImportAnnotation]
@@ -244,10 +263,15 @@ func buildManifestConfigs(managedCluster *clusterv1.ManagedCluster, manifests []
 		}
 
 		gvk := obj.GetObjectKind().GroupVersionKind()
+		// Use UnsafeGuessKindToResource to convert Kind to the plural resource name
+		// (e.g. "Secret" -> "secrets", "PriorityClass" -> "priorityclasses").
+		// The work-agent's resourceMatch function requires an exact match on the Resource
+		// field — leaving it empty causes the ReadOnly config to never match.
+		plural, _ := meta.UnsafeGuessKindToResource(gvk)
 		config := workv1.ManifestConfigOption{
 			ResourceIdentifier: workv1.ResourceIdentifier{
 				Group:     gvk.Group,
-				Resource:  "", // Will be inferred by work-agent from GVK
+				Resource:  plural.Resource,
 				Name:      metadata.GetName(),
 				Namespace: metadata.GetNamespace(),
 			},

--- a/pkg/controller/manifestwork/manifestwork_controller_test.go
+++ b/pkg/controller/manifestwork/manifestwork_controller_test.go
@@ -191,7 +191,16 @@ func TestReconcile(t *testing.T) {
 					return
 				}
 
-				// Verify all configs have ReadOnly strategy
+				// Verify the number of configs matches the number of manifests — every
+				// manifest must have a corresponding ReadOnly config.
+				if len(klusterletWork.Spec.ManifestConfigs) != len(klusterletWork.Spec.Workload.Manifests) {
+					t.Errorf("expected %d ManifestConfigs (one per manifest), got %d",
+						len(klusterletWork.Spec.Workload.Manifests), len(klusterletWork.Spec.ManifestConfigs))
+				}
+
+				// Verify all configs have ReadOnly strategy and a non-empty Resource field.
+				// A non-empty Resource field is required for the work-agent's resourceMatch
+				// function to correctly identify and apply the ReadOnly strategy.
 				for i, config := range klusterletWork.Spec.ManifestConfigs {
 					if config.UpdateStrategy == nil {
 						t.Errorf("ManifestConfig %d has nil UpdateStrategy", i)
@@ -200,6 +209,10 @@ func TestReconcile(t *testing.T) {
 					if config.UpdateStrategy.Type != workv1.UpdateStrategyTypeReadOnly {
 						t.Errorf("ManifestConfig %d has UpdateStrategy %s, expected ReadOnly",
 							i, config.UpdateStrategy.Type)
+					}
+					if config.ResourceIdentifier.Resource == "" {
+						t.Errorf("ManifestConfig %d has empty Resource field — work-agent resourceMatch will never match this config",
+							i)
 					}
 				}
 
@@ -215,7 +228,13 @@ func TestReconcile(t *testing.T) {
 					return
 				}
 
-				// Verify CRDs config has ReadOnly strategy
+				// Verify the number of configs matches the number of manifests.
+				if len(crdsWork.Spec.ManifestConfigs) != len(crdsWork.Spec.Workload.Manifests) {
+					t.Errorf("expected %d CRDs ManifestConfigs (one per manifest), got %d",
+						len(crdsWork.Spec.Workload.Manifests), len(crdsWork.Spec.ManifestConfigs))
+				}
+
+				// Verify CRDs configs have ReadOnly strategy and a non-empty Resource field.
 				for i, config := range crdsWork.Spec.ManifestConfigs {
 					if config.UpdateStrategy == nil {
 						t.Errorf("CRDs ManifestConfig %d has nil UpdateStrategy", i)
@@ -224,6 +243,10 @@ func TestReconcile(t *testing.T) {
 					if config.UpdateStrategy.Type != workv1.UpdateStrategyTypeReadOnly {
 						t.Errorf("CRDs ManifestConfig %d has UpdateStrategy %s, expected ReadOnly",
 							i, config.UpdateStrategy.Type)
+					}
+					if config.ResourceIdentifier.Resource == "" {
+						t.Errorf("CRDs ManifestConfig %d has empty Resource field — work-agent resourceMatch will never match this config",
+							i)
 					}
 				}
 			},

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -906,6 +906,10 @@ func assertManagedClusterManifestWorksReadOnly(clusterName string) {
 			if len(klusterletCRDs.Spec.ManifestConfigs) == 0 {
 				return fmt.Errorf("klusterlet-crds ManifestWork has no ManifestConfigs")
 			}
+			if len(klusterletCRDs.Spec.ManifestConfigs) != len(klusterletCRDs.Spec.Workload.Manifests) {
+				return fmt.Errorf("klusterlet-crds ManifestWork has %d ManifestConfigs but %d manifests — every manifest must have a config",
+					len(klusterletCRDs.Spec.ManifestConfigs), len(klusterletCRDs.Spec.Workload.Manifests))
+			}
 			for i, config := range klusterletCRDs.Spec.ManifestConfigs {
 				if config.UpdateStrategy == nil {
 					return fmt.Errorf("klusterlet-crds ManifestConfig %d has nil UpdateStrategy", i)
@@ -913,6 +917,10 @@ func assertManagedClusterManifestWorksReadOnly(clusterName string) {
 				if config.UpdateStrategy.Type != workv1.UpdateStrategyTypeReadOnly {
 					return fmt.Errorf("klusterlet-crds ManifestConfig %d has UpdateStrategy %s, expected ReadOnly",
 						i, config.UpdateStrategy.Type)
+				}
+				if config.ResourceIdentifier.Resource == "" {
+					return fmt.Errorf("klusterlet-crds ManifestConfig %d has empty Resource field — work-agent resourceMatch will never match this config",
+						i)
 				}
 			}
 
@@ -924,6 +932,10 @@ func assertManagedClusterManifestWorksReadOnly(clusterName string) {
 			if len(klusterlet.Spec.ManifestConfigs) == 0 {
 				return fmt.Errorf("klusterlet ManifestWork has no ManifestConfigs")
 			}
+			if len(klusterlet.Spec.ManifestConfigs) != len(klusterlet.Spec.Workload.Manifests) {
+				return fmt.Errorf("klusterlet ManifestWork has %d ManifestConfigs but %d manifests — every manifest must have a config",
+					len(klusterlet.Spec.ManifestConfigs), len(klusterlet.Spec.Workload.Manifests))
+			}
 			for i, config := range klusterlet.Spec.ManifestConfigs {
 				if config.UpdateStrategy == nil {
 					return fmt.Errorf("klusterlet ManifestConfig %d has nil UpdateStrategy", i)
@@ -931,6 +943,10 @@ func assertManagedClusterManifestWorksReadOnly(clusterName string) {
 				if config.UpdateStrategy.Type != workv1.UpdateStrategyTypeReadOnly {
 					return fmt.Errorf("klusterlet ManifestConfig %d has UpdateStrategy %s, expected ReadOnly",
 						i, config.UpdateStrategy.Type)
+				}
+				if config.ResourceIdentifier.Resource == "" {
+					return fmt.Errorf("klusterlet ManifestConfig %d has empty Resource field — work-agent resourceMatch will never match this config",
+						i)
 				}
 			}
 


### PR DESCRIPTION
The buildManifestConfigs function in PR #1109 set Resource: "" on all ManifestConfigOption entries with the comment "Will be inferred by work-agent from GVK". However, the work-agent's resourceMatch function performs an exact string comparison on the Resource field and does not infer anything from the GVK. Empty string never matches the actual resource type (e.g. "secrets", "priorityclasses"), so the ReadOnly strategy was silently never applied to any manifest.

This caused the DR restore race condition that #1109 intended to fix: the backup hub's work-agent continued to overwrite bootstrap-hub-kubeconfig on the spoke with the backup hub's version, preventing the spoke from reconnecting to the restore hub.

Fix: use meta.UnsafeGuessKindToResource to convert Kind to the plural resource name (e.g. Secret -> secrets, PriorityClass -> priorityclasses). This correctly resolves all 9 types currently in the klusterlet ManifestWorks.

Also update unit and E2E tests to verify the Resource field is non-empty and that the number of ManifestConfigs matches the number of manifests. These checks would have caught the original bug.

Fixes: ACM-38012