### PR TITLE
chore(deps): update ocm to v1.2.1 for MCE 2.17 [backplane-2.17]

### DIFF
--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -1,6 +1,6 @@
 # Copyright Contributors to the Open Cluster Management project
 
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS builder
 
 ENV REMOTE_SOURCE='.'
 ENV REMOTE_SOURCE_DIR='/remote-source'

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/managedcluster-import-controller
 
-go 1.25.0
+go 1.26.0
 
 // TODO: @xuezhaojun need to switch to the official flightctl lib once it's ready.
 replace github.com/flightctl/flightctl/lib => github.com/xuezhaojun/flightctl/lib v0.0.0-20241125124411-7eec33f53a61
@@ -30,7 +30,7 @@ require (
 	k8s.io/klog/v2 v2.130.1
 	k8s.io/utils v0.0.0-20260108192941-914a6e750570
 	open-cluster-management.io/api v1.2.0
-	open-cluster-management.io/sdk-go v1.1.1-0.20260127092137-c07e0fafa331
+	open-cluster-management.io/sdk-go v1.2.0
 	sigs.k8s.io/controller-runtime v0.23.2
 )
 
@@ -42,7 +42,7 @@ require (
 	github.com/openshift/hypershift/api v0.0.0-20241022184855-1fa7be0211e4
 	github.com/sethvargo/go-password v0.2.0
 	github.com/stretchr/testify v1.11.1
-	open-cluster-management.io/ocm v1.1.1-0.20260128054152-9d1a993e2c6f
+	open-cluster-management.io/ocm v1.2.1
 	sigs.k8s.io/cluster-api v1.9.3
 	sigs.k8s.io/yaml v1.6.0
 )

--- a/go.sum
+++ b/go.sum
@@ -729,10 +729,10 @@ k8s.io/utils v0.0.0-20260108192941-914a6e750570 h1:JT4W8lsdrGENg9W+YwwdLJxklIuKW
 k8s.io/utils v0.0.0-20260108192941-914a6e750570/go.mod h1:xDxuJ0whA3d0I4mf/C4ppKHxXynQ+fxnkmQH0vTHnuk=
 open-cluster-management.io/api v1.2.0 h1:+yeQgJiErrur5S4s205UM37EcZ2XbC9pFSm0xgV5/hU=
 open-cluster-management.io/api v1.2.0/go.mod h1:YcmA6SpGEekIMxdoeVIIyOaBhMA6ImWRLXP4g8n8T+4=
-open-cluster-management.io/ocm v1.1.1-0.20260128054152-9d1a993e2c6f h1:ldD9fiq0VzL62Idt69eXEUnEp2bXkxIiB37AWIeOxBM=
-open-cluster-management.io/ocm v1.1.1-0.20260128054152-9d1a993e2c6f/go.mod h1:kgM23lXGK+kwNBZhefpDSuryAUmNMb8BqWTzxjALOuM=
-open-cluster-management.io/sdk-go v1.1.1-0.20260127092137-c07e0fafa331 h1:7EcnxNPXQgQxOi2Hv2nYGsTxxFYt3nwGHee5eJlOuz8=
-open-cluster-management.io/sdk-go v1.1.1-0.20260127092137-c07e0fafa331/go.mod h1:4haPv/uuKqQ3gxi62/PPknlrUFi132ga0KYLwj5tpx0=
+open-cluster-management.io/ocm v1.2.1 h1:JC1mrIkaNjJ+AmLjiQ/sIhUE6Uzb3JVXFlFbaZF5+VY=
+open-cluster-management.io/ocm v1.2.1/go.mod h1:7jQB00gs+BxpvPTWvEWZ7x6RrkgqxLkVpqLpaCLmG8c=
+open-cluster-management.io/sdk-go v1.2.0 h1:O9LCOoy5JfgK3k4e2OCBY2ZoCqBEwLbEWClqP01FkQI=
+open-cluster-management.io/sdk-go v1.2.0/go.mod h1:OHM74Kw1gh9RHxg7QjJlGXCDlPm7x2CtCkejHSdczs4=
 sigs.k8s.io/cluster-api v1.9.3 h1:lKWbrXzyNmJh++IcX54ZbAmnO7tZ2wKgds7WvskpiXY=
 sigs.k8s.io/cluster-api v1.9.3/go.mod h1:5iojv38PSvOd4cxqu08Un5TQmy2yBkd3+0U7R/e+msk=
 sigs.k8s.io/controller-runtime v0.23.2 h1:Oh3FliXaA2CS1chpUXvjVNJtsvGZYUxQH8s7bvR7aXk=

--- a/pkg/bootstrap/bootstrapkubeconfig.go
+++ b/pkg/bootstrap/bootstrapkubeconfig.go
@@ -41,6 +41,11 @@ import (
 const (
 	apiServerInternalEndpoint   = "https://kubernetes.default.svc:443"
 	apiServerInternalEndpointCA = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+
+	clusterResourceName = "cluster"
+	caBundleCrtKey      = "ca-bundle.crt"
+	caCrtKey            = "ca.crt"
+	tlsCrtKey           = "tls.crt"
 )
 
 // create kubeconfig for bootstrap
@@ -246,7 +251,7 @@ func GetKubeAPIServerAddress(ctx context.Context, client client.Client,
 	}
 
 	infraConfig := &ocinfrav1.Infrastructure{}
-	err := client.Get(ctx, types.NamespacedName{Name: "cluster"}, infraConfig)
+	err := client.Get(ctx, types.NamespacedName{Name: clusterResourceName}, infraConfig)
 	if err == nil {
 		return infraConfig.Status.APIServerURL, nil
 	}
@@ -272,7 +277,7 @@ func GetKubeconfigClusterName(ctx context.Context, client client.Client) (string
 	}
 
 	infraConfig := &ocinfrav1.Infrastructure{}
-	err := client.Get(ctx, types.NamespacedName{Name: "cluster"}, infraConfig)
+	err := client.Get(ctx, types.NamespacedName{Name: clusterResourceName}, infraConfig)
 	if err == nil {
 		return string(infraConfig.UID), nil
 	}
@@ -422,7 +427,7 @@ func autoDetectCAData(ctx context.Context, clientHolder *helpers.ClientHolder, k
 
 func getKubeRootCABundle(ctx context.Context, clientHolder *helpers.ClientHolder,
 	caNamespace string) ([]byte, error) {
-	return getCABundleFromConfigmap(ctx, clientHolder, caNamespace, "kube-root-ca.crt", "ca.crt")
+	return getCABundleFromConfigmap(ctx, clientHolder, caNamespace, "kube-root-ca.crt", caCrtKey)
 }
 
 func getCABundleFromConfigmap(ctx context.Context, clientHolder *helpers.ClientHolder,
@@ -433,7 +438,7 @@ func getCABundleFromConfigmap(ctx context.Context, clientHolder *helpers.ClientH
 	}
 
 	if len(caKeys) == 0 {
-		caKeys = []string{"ca-bundle.crt", "ca.crt", "tls.crt"}
+		caKeys = []string{caBundleCrtKey, caCrtKey, tlsCrtKey}
 	}
 
 	for _, key := range caKeys {
@@ -449,7 +454,7 @@ func getCABundleFromConfigmap(ctx context.Context, clientHolder *helpers.ClientH
 // returns the first one which has a name matches the given dnsName
 func getKubeAPIServerSecretName(ctx context.Context, client client.Client, dnsName string) (string, error) {
 	apiserver := &ocinfrav1.APIServer{}
-	if err := client.Get(ctx, types.NamespacedName{Name: "cluster"}, apiserver); err != nil {
+	if err := client.Get(ctx, types.NamespacedName{Name: clusterResourceName}, apiserver); err != nil {
 		if helpers.ResourceIsNotFound(err) {
 			klog.Info("Ignore ocp apiserver, it is not found")
 			return "", nil
@@ -502,7 +507,7 @@ func getCustomKubeAPIServerCertificate(ctx context.Context, kubeClient kubernete
 		return nil, err
 	}
 
-	res, ok := secret.Data["tls.crt"]
+	res, ok := secret.Data[tlsCrtKey]
 	if !ok {
 		return nil, fmt.Errorf("failed to find data[tls.crt] in secret openshift-config/%s", secretName)
 	}

--- a/pkg/bootstrap/bootstrapkubeconfig.go
+++ b/pkg/bootstrap/bootstrapkubeconfig.go
@@ -42,10 +42,9 @@ const (
 	apiServerInternalEndpoint   = "https://kubernetes.default.svc:443"
 	apiServerInternalEndpointCA = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 
-	clusterResourceName = "cluster"
-	caBundleCrtKey      = "ca-bundle.crt"
-	caCrtKey            = "ca.crt"
-	tlsCrtKey           = "tls.crt"
+	caBundleCrtKey = "ca-bundle.crt"
+	caCrtKey       = "ca.crt"
+	tlsCrtKey      = "tls.crt"
 )
 
 // create kubeconfig for bootstrap
@@ -251,7 +250,7 @@ func GetKubeAPIServerAddress(ctx context.Context, client client.Client,
 	}
 
 	infraConfig := &ocinfrav1.Infrastructure{}
-	err := client.Get(ctx, types.NamespacedName{Name: clusterResourceName}, infraConfig)
+	err := client.Get(ctx, types.NamespacedName{Name: constants.ClusterResourceName}, infraConfig)
 	if err == nil {
 		return infraConfig.Status.APIServerURL, nil
 	}
@@ -277,7 +276,7 @@ func GetKubeconfigClusterName(ctx context.Context, client client.Client) (string
 	}
 
 	infraConfig := &ocinfrav1.Infrastructure{}
-	err := client.Get(ctx, types.NamespacedName{Name: clusterResourceName}, infraConfig)
+	err := client.Get(ctx, types.NamespacedName{Name: constants.ClusterResourceName}, infraConfig)
 	if err == nil {
 		return string(infraConfig.UID), nil
 	}
@@ -454,7 +453,7 @@ func getCABundleFromConfigmap(ctx context.Context, clientHolder *helpers.ClientH
 // returns the first one which has a name matches the given dnsName
 func getKubeAPIServerSecretName(ctx context.Context, client client.Client, dnsName string) (string, error) {
 	apiserver := &ocinfrav1.APIServer{}
-	if err := client.Get(ctx, types.NamespacedName{Name: clusterResourceName}, apiserver); err != nil {
+	if err := client.Get(ctx, types.NamespacedName{Name: constants.ClusterResourceName}, apiserver); err != nil {
 		if helpers.ResourceIsNotFound(err) {
 			klog.Info("Ignore ocp apiserver, it is not found")
 			return "", nil

--- a/pkg/bootstrap/bootstrapkubeconfig_test.go
+++ b/pkg/bootstrap/bootstrapkubeconfig_test.go
@@ -1521,7 +1521,7 @@ func TestGetBootstrapToken(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-bootstrap-sa-token-abc123",
 						Namespace: "test-cluster",
-						Labels: map[string]string{
+						Labels: map[string]string{ // #nosec G101 -- test label, not a credential
 							"kubernetes.io/legacy-token-invalid-since": "2024-01-01T00:00:00Z",
 						},
 					},
@@ -1565,7 +1565,7 @@ func TestGetBootstrapToken(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-bootstrap-sa-token-abc123",
 						Namespace: "test-cluster",
-						Labels: map[string]string{
+						Labels: map[string]string{ // #nosec G101 -- test label, not a credential
 							"kubernetes.io/legacy-token-invalid-since": "2099-01-01T00:00:00Z",
 						},
 					},

--- a/pkg/bootstrap/render.go
+++ b/pkg/bootstrap/render.go
@@ -62,6 +62,7 @@ var reservedClusterClaimSuffixes = []string{
 const (
 	grpcRouteName   = "grpc-server"
 	grpcCAConfigmap = "ca-bundle-configmap"
+	grpcAuthType    = "grpc"
 
 	// grpcServiceName is the LoadBalancer Service name that exposes the gRPC server on non-OpenShift clusters.
 	// The cluster-manager operator automatically creates this service in the "open-cluster-management-hub" namespace.
@@ -371,7 +372,7 @@ func (c *KlusterletManifestsConfig) Generate(ctx context.Context,
 	if c.klusterletConfig != nil && c.klusterletConfig.Spec.RegistrationDriver != nil {
 		c.chartConfig.Klusterlet.RegistrationConfiguration.RegistrationDriver = *c.klusterletConfig.Spec.RegistrationDriver
 
-		if c.klusterletConfig.Spec.RegistrationDriver.AuthType == "grpc" {
+		if c.klusterletConfig.Spec.RegistrationDriver.AuthType == grpcAuthType {
 			// TODO: support MultiHubBootstrapHubKubeConfigs here
 			_, _, _, _, tokenString, _, err := helpers.ParseKubeConfigData([]byte(c.chartConfig.BootstrapHubKubeConfig))
 			if err != nil {

--- a/pkg/bootstrap/render_test.go
+++ b/pkg/bootstrap/render_test.go
@@ -1153,7 +1153,7 @@ func TestKlusterletConfigGenerate(t *testing.T) {
 			).WithManagedCluster(&v1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   "test-ocp",
-					Labels: map[string]string{"vendor": "OpenShift"},
+					Labels: map[string]string{"vendor": vendorOpenShift},
 				},
 			}).WithoutImagePullSecretGenerate(),
 			validateFunc: func(t *testing.T, objs, crds []runtime.Object) {
@@ -1171,7 +1171,7 @@ func TestKlusterletConfigGenerate(t *testing.T) {
 								len(o.Spec.Template.Spec.Containers))
 						}
 						sidecar := o.Spec.Template.Spec.Containers[1]
-						if sidecar.Name != "tls-profile-sync" {
+						if sidecar.Name != tlsProfileSyncName {
 							t.Errorf("sidecar name = %q, want tls-profile-sync", sidecar.Name)
 						}
 						if sidecar.Image !=

--- a/pkg/bootstrap/sidecar.go
+++ b/pkg/bootstrap/sidecar.go
@@ -18,14 +18,19 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-const klusterletDeploymentName = "klusterlet"
+const (
+	klusterletDeploymentName = "klusterlet"
+	vendorOpenShift          = "OpenShift"
+	kindDeployment           = "Deployment"
+	tlsProfileSyncName       = "tls-profile-sync"
+)
 
 // isManagedClusterOpenShift returns true if the managed cluster is an OpenShift cluster.
 func isManagedClusterOpenShift(mc *clusterv1.ManagedCluster) bool {
 	if mc == nil {
 		return false
 	}
-	return mc.Labels["vendor"] == "OpenShift"
+	return mc.Labels["vendor"] == vendorOpenShift
 }
 
 // getTLSProfileSyncImage returns the tls-profile-sync sidecar image, applying registry
@@ -65,7 +70,7 @@ func injectTLSProfileSyncSidecar(
 		if err := yaml.Unmarshal(obj, u); err != nil {
 			continue
 		}
-		if u.GetKind() != "Deployment" || u.GetName() != klusterletDeploymentName {
+		if u.GetKind() != kindDeployment || u.GetName() != klusterletDeploymentName {
 			continue
 		}
 
@@ -75,10 +80,10 @@ func injectTLSProfileSyncSidecar(
 		}
 
 		sidecar := corev1.Container{
-			Name:            "tls-profile-sync",
+			Name:            tlsProfileSyncName,
 			Image:           image,
 			ImagePullPolicy: corev1.PullIfNotPresent,
-			Command:         []string{"/usr/local/bin/tls-profile-sync"},
+			Command:         []string{"/usr/local/bin/" + tlsProfileSyncName},
 			Env: []corev1.EnvVar{
 				{
 					Name: "POD_NAMESPACE",

--- a/pkg/bootstrap/sidecar_test.go
+++ b/pkg/bootstrap/sidecar_test.go
@@ -36,7 +36,7 @@ func TestIsManagedClusterOpenShift(t *testing.T) {
 			name: "vendor OpenShift",
 			mc: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"vendor": "OpenShift"},
+					Labels: map[string]string{"vendor": vendorOpenShift},
 				},
 			},
 			want: true,
@@ -137,7 +137,7 @@ func TestInjectTLSProfileSyncSidecar(t *testing.T) {
 
 	t.Run("injects sidecar into klusterlet deployment", func(t *testing.T) {
 		deployment := &appsv1.Deployment{
-			TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
+			TypeMeta: metav1.TypeMeta{Kind: kindDeployment, APIVersion: "apps/v1"},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "klusterlet",
 				Namespace: "open-cluster-management-agent",
@@ -179,7 +179,7 @@ func TestInjectTLSProfileSyncSidecar(t *testing.T) {
 		}
 
 		sidecar := modified.Spec.Template.Spec.Containers[1]
-		if sidecar.Name != "tls-profile-sync" {
+		if sidecar.Name != tlsProfileSyncName {
 			t.Errorf("sidecar name = %q, want tls-profile-sync", sidecar.Name)
 		}
 		if sidecar.Image != "quay.io/ocm/import-controller:v1" {
@@ -226,7 +226,7 @@ func TestInjectTLSProfileSyncSidecar(t *testing.T) {
 
 	t.Run("non-klusterlet deployment is not modified", func(t *testing.T) {
 		deployment := &appsv1.Deployment{
-			TypeMeta:   metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
+			TypeMeta:   metav1.TypeMeta{Kind: kindDeployment, APIVersion: "apps/v1"},
 			ObjectMeta: metav1.ObjectMeta{Name: "other-deployment"},
 			Spec: appsv1.DeploymentSpec{
 				Template: corev1.PodTemplateSpec{

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -70,6 +70,9 @@ const (
 	HostedClusterLabel       = "import.open-cluster-management.io/hosted-cluster"
 )
 
+// TrueString is the string representation of the boolean true value used in labels and annotations.
+const TrueString = "true"
+
 const (
 	CreatedViaAnnotation = "open-cluster-management/created-via"
 	CreatedViaAI         = "assisted-installer"

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -73,6 +73,10 @@ const (
 // TrueString is the string representation of the boolean true value used in labels and annotations.
 const TrueString = "true"
 
+// ClusterResourceName is the singleton name used by OpenShift cluster-scoped
+// resources such as Infrastructure and APIServer.
+const ClusterResourceName = "cluster"
+
 const (
 	CreatedViaAnnotation = "open-cluster-management/created-via"
 	CreatedViaAI         = "assisted-installer"

--- a/pkg/controller/agentregistration/server.go
+++ b/pkg/controller/agentregistration/server.go
@@ -140,7 +140,11 @@ func RunAgentRegistrationServer(ctx context.Context, port int, clientHolder *hel
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
 
-		_, err = w.Write(content)
+		w.Header().Set("Content-Type", "application/yaml")
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		// content is server-generated klusterlet YAML manifests, served with a
+		// non-HTML Content-Type and nosniff, so it cannot be interpreted as HTML.
+		_, err = w.Write(content) // #nosec G705 -- server-generated YAML, not reflected user input
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}

--- a/pkg/controller/agentregistration/server.go
+++ b/pkg/controller/agentregistration/server.go
@@ -121,7 +121,7 @@ func RunAgentRegistrationServer(ctx context.Context, port int, clientHolder *hel
 		}
 
 		klusterletClusterAnnotations := map[string]string{
-			"agent.open-cluster-management.io/create-with-default-klusterletaddonconfig": "true",
+			"agent.open-cluster-management.io/create-with-default-klusterletaddonconfig": constants.TrueString,
 		}
 		if klusterletconfigName != "" {
 			// This annotation will finanlly be added on the managedcluster which created by the agent side.

--- a/pkg/controller/autoimport/autoimport_controller.go
+++ b/pkg/controller/autoimport/autoimport_controller.go
@@ -129,7 +129,7 @@ func (r *ReconcileAutoImport) Reconcile(ctx context.Context, request reconcile.R
 	}
 
 	backupRestore := false
-	if v, ok := autoImportSecret.Labels[constants.LabelAutoImportRestore]; ok && strings.EqualFold(v, "true") {
+	if v, ok := autoImportSecret.Labels[constants.LabelAutoImportRestore]; ok && strings.EqualFold(v, constants.TrueString) {
 		backupRestore = true
 	}
 

--- a/pkg/controller/flightctl/flightctl.go
+++ b/pkg/controller/flightctl/flightctl.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"time"
 
@@ -250,6 +251,15 @@ func (f *FlightCtlManager) isFlightCtlEnabledAndHealthy() error {
 		return fmt.Errorf("healthEndpoint not found in flightctl-discovery configmap")
 	}
 
+	// Validate the health endpoint URL to ensure only HTTPS requests are made.
+	parsedHealthEndpoint, err := url.Parse(healthEndpoint)
+	if err != nil {
+		return fmt.Errorf("invalid healthEndpoint %q: %v", healthEndpoint, err)
+	}
+	if parsedHealthEndpoint.Scheme != "https" {
+		return fmt.Errorf("invalid healthEndpoint %q: only https scheme is allowed", healthEndpoint)
+	}
+
 	// Get the flightctl namespace from the ConfigMap
 	flightctlNamespace, ok := cm.Data["namespace"]
 	if !ok || flightctlNamespace == "" {
@@ -292,7 +302,9 @@ func (f *FlightCtlManager) isFlightCtlEnabledAndHealthy() error {
 			},
 		},
 	}
-	resp, err := client.Get(healthEndpoint)
+	// The endpoint is validated above to be an https URL and originates from a
+	// cluster-admin managed ConfigMap, not from end-user request input.
+	resp, err := client.Get(parsedHealthEndpoint.String()) // #nosec G704 -- validated admin-provided https endpoint
 	if err != nil {
 		return fmt.Errorf("failed to perform health check: %v", err)
 	}

--- a/pkg/controller/hosted/controller.go
+++ b/pkg/controller/hosted/controller.go
@@ -38,6 +38,8 @@ var manifestFiles embed.FS
 
 var klusterletHostedExternalKubeconfig = "manifests/external_managed_secret.yaml"
 
+const readyToApplyStatusName = "ReadyToApply-status"
+
 var log = logf.Log.WithName(ControllerName)
 
 // ReconcileHosted reconciles the Hosted mode ManagedClusters of the ManifestWorks object
@@ -313,7 +315,7 @@ func (r *ReconcileHosted) externalManagedKubeconfigCreated(
 		}
 
 		for _, fb := range manifest.StatusFeedbacks.Values {
-			if fb.Name == "ReadyToApply-status" &&
+			if fb.Name == readyToApplyStatusName &&
 				fb.Value.String != nil && strings.EqualFold(*fb.Value.String, "True") {
 				return true, nil
 			}
@@ -388,7 +390,7 @@ func createHostingManifestWork(managedClusterName string,
 									Path: `.status.conditions[?(@.type=="ReadyToApply")].reason`,
 								},
 								{
-									Name: "ReadyToApply-status",
+									Name: readyToApplyStatusName,
 									Path: `.status.conditions[?(@.type=="ReadyToApply")].status`,
 								},
 								{

--- a/pkg/controller/hosted/controller.go
+++ b/pkg/controller/hosted/controller.go
@@ -435,7 +435,7 @@ func createManagedKubeconfigManifestWork(managedClusterName string, importSecret
 	isLocalCluster := false
 	if hostingCluster != nil && hostingCluster.Labels != nil {
 		localClusterValue, exists := hostingCluster.Labels[constants.SelfManagedLabel]
-		if exists && localClusterValue == "true" {
+		if exists && localClusterValue == constants.TrueString {
 			isLocalCluster = true
 		}
 	}

--- a/pkg/controller/importconfig/cluster_info.go
+++ b/pkg/controller/importconfig/cluster_info.go
@@ -235,7 +235,7 @@ func isSelfManaged(managedCluster *clusterv1.ManagedCluster) bool {
 	if managedCluster == nil {
 		return false
 	}
-	if value := managedCluster.Labels[constants.SelfManagedLabel]; strings.EqualFold(value, "true") {
+	if value := managedCluster.Labels[constants.SelfManagedLabel]; strings.EqualFold(value, constants.TrueString) {
 		return true
 	}
 	return false

--- a/pkg/controller/managedcluster/managedcluster_controller.go
+++ b/pkg/controller/managedcluster/managedcluster_controller.go
@@ -176,7 +176,7 @@ func ensureAddonHostingAnnotation(modified *bool, cluster *clusterv1.ManagedClus
 	hostingClusterName := annotations[constants.HostingClusterNameAnnotation]
 	addonHostingClusterName, existed := annotations[addonv1alpha1.HostingClusterNameAnnotationKey]
 
-	if !helpers.IsHostedCluster(cluster) || enabledHostedAddon != "true" || hostingClusterName == "" {
+	if !helpers.IsHostedCluster(cluster) || enabledHostedAddon != constants.TrueString || hostingClusterName == "" {
 		if existed {
 			delete(cluster.Annotations, addonv1alpha1.HostingClusterNameAnnotationKey)
 			*modified = true

--- a/pkg/controller/manifestwork/manifestwork_controller.go
+++ b/pkg/controller/manifestwork/manifestwork_controller.go
@@ -88,7 +88,7 @@ func (r *ReconcileManifestWork) Reconcile(ctx context.Context, request reconcile
 		return reconcile.Result{}, nil
 	}
 
-	workSelector := labels.SelectorFromSet(map[string]string{constants.KlusterletWorksLabel: "true"})
+	workSelector := labels.SelectorFromSet(map[string]string{constants.KlusterletWorksLabel: constants.TrueString})
 	manifestWorks, err := r.informerHolder.KlusterletWorkLister.ManifestWorks(managedClusterName).List(workSelector)
 	if err != nil {
 		return reconcile.Result{}, err
@@ -147,7 +147,7 @@ func createManifestWorks(
 				Name:      fmt.Sprintf("%s-%s", managedCluster.Name, constants.KlusterletCRDsSuffix),
 				Namespace: managedCluster.Name,
 				Labels: map[string]string{
-					constants.KlusterletWorksLabel: "true",
+					constants.KlusterletWorksLabel: constants.TrueString,
 				},
 				Annotations: map[string]string{
 					// make sure the crd manifestWork is the last to be deleted.
@@ -184,7 +184,7 @@ func createManifestWorks(
 			Name:      fmt.Sprintf("%s-%s", managedCluster.Name, constants.KlusterletSuffix),
 			Namespace: managedCluster.Name,
 			Labels: map[string]string{
-				constants.KlusterletWorksLabel: "true",
+				constants.KlusterletWorksLabel: constants.TrueString,
 			},
 		},
 		Spec: workv1.ManifestWorkSpec{

--- a/pkg/controller/selfmanagedcluster/manager.go
+++ b/pkg/controller/selfmanagedcluster/manager.go
@@ -74,7 +74,7 @@ func Add(ctx context.Context,
 						// case 1: handle the label changed and new self managed label is true
 						newLabels := e.ObjectNew.GetLabels()
 						if !equality.Semantic.DeepEqual(e.ObjectOld.GetLabels(), newLabels) &&
-							strings.EqualFold(newLabels[constants.SelfManagedLabel], "true") {
+							strings.EqualFold(newLabels[constants.SelfManagedLabel], constants.TrueString) {
 							return true
 						}
 

--- a/pkg/controller/selfmanagedcluster/selfmanagedcluster_controller.go
+++ b/pkg/controller/selfmanagedcluster/selfmanagedcluster_controller.go
@@ -86,7 +86,7 @@ func (r *ReconcileLocalCluster) Reconcile(ctx context.Context, request reconcile
 	}
 
 	if selfManaged, ok := managedCluster.Labels[constants.SelfManagedLabel]; !ok ||
-		!strings.EqualFold(selfManaged, "true") {
+		!strings.EqualFold(selfManaged, constants.TrueString) {
 		return reconcile.Result{}, nil
 	}
 

--- a/pkg/helpers/autoimport.go
+++ b/pkg/helpers/autoimport.go
@@ -148,7 +148,7 @@ func (i *ImportHelper) Import(backupRestore bool, cluster *clusterv1.ManagedClus
 	}
 
 	// ensure the klusterlet manifest works exist
-	workSelector := labels.SelectorFromSet(map[string]string{constants.KlusterletWorksLabel: "true"})
+	workSelector := labels.SelectorFromSet(map[string]string{constants.KlusterletWorksLabel: constants.TrueString})
 	manifestWorks, err := i.informerHolder.KlusterletWorkLister.ManifestWorks(clusterName).List(workSelector)
 	if err != nil && !errors.IsNotFound(err) {
 		return reconcile.Result{},

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -252,19 +252,24 @@ func buildImportClient(config *clientcmdapi.Config) (reconcile.Result, *ClientHo
 }
 
 func buildKubeConfigFileWithToken(apiURL, token string) *clientcmdapi.Config {
+	const (
+		defaultCluster = "default-cluster"
+		defaultAuth    = "default-auth"
+		defaultContext = "default-context"
+	)
 	return &clientcmdapi.Config{
-		Clusters: map[string]*clientcmdapi.Cluster{"default-cluster": {
+		Clusters: map[string]*clientcmdapi.Cluster{defaultCluster: {
 			Server:                apiURL,
 			InsecureSkipTLSVerify: true,
 		}},
-		AuthInfos: map[string]*clientcmdapi.AuthInfo{"default-auth": {
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{defaultAuth: {
 			Token: token,
 		}},
-		Contexts: map[string]*clientcmdapi.Context{"default-context": {
-			Cluster:  "default-cluster",
-			AuthInfo: "default-auth",
+		Contexts: map[string]*clientcmdapi.Context{defaultContext: {
+			Cluster:  defaultCluster,
+			AuthInfo: defaultAuth,
 		}},
-		CurrentContext: "default-context",
+		CurrentContext: defaultContext,
 	}
 }
 

--- a/pkg/helpers/importcontrollerconfig.go
+++ b/pkg/helpers/importcontrollerconfig.go
@@ -57,7 +57,7 @@ func (c *ImportControllerConfig) GenerateImportConfig() (bool, error) {
 		return false, err
 	}
 
-	if cm.Data[constants.ClusterImportConfig] == "true" {
+	if cm.Data[constants.ClusterImportConfig] == constants.TrueString {
 		return true, nil
 	}
 	return false, nil

--- a/pkg/helpers/tls.go
+++ b/pkg/helpers/tls.go
@@ -10,6 +10,7 @@ import (
 
 	ocinfrav1 "github.com/openshift/api/config/v1"
 	tlsprofile "github.com/stolostron/cluster-lifecycle-api/helpers/tlsprofile"
+	"github.com/stolostron/managedcluster-import-controller/pkg/constants"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -30,7 +31,7 @@ func GetTLSConfigForServer(runtimeClient client.Reader) *tls.Config {
 	defer cancel()
 
 	apiServer := &ocinfrav1.APIServer{}
-	if err := runtimeClient.Get(ctx, client.ObjectKey{Name: "cluster"}, apiServer); err != nil {
+	if err := runtimeClient.Get(ctx, client.ObjectKey{Name: constants.ClusterResourceName}, apiServer); err != nil {
 		klog.V(4).Infof("Failed to get hub APIServer for TLS config, using TLS 1.2 fallback: %v", err)
 		return &tls.Config{
 			MinVersion: tls.VersionTLS12,

--- a/pkg/tlsprofilesync/sync.go
+++ b/pkg/tlsprofilesync/sync.go
@@ -11,6 +11,7 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	libgocrypto "github.com/openshift/library-go/pkg/crypto"
+	"github.com/stolostron/managedcluster-import-controller/pkg/constants"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,6 +36,11 @@ const (
 	// Upstream OCM components watch this ConfigMap to get TLS settings without
 	// depending on OpenShift APIs.
 	ConfigMapName = "ocm-tls-profile"
+
+	minTLSVersionKey       = "minTLSVersion"
+	cipherSuitesKey        = "cipherSuites"
+	profileTypeKey         = "profileType"
+	tlsProfileSyncCtrlName = "tls-profile-sync"
 )
 
 // Run starts the tls-profile-sync sidecar using the controller-runtime pattern.
@@ -101,7 +107,7 @@ func Run(ctx context.Context) error {
 		namespace:  namespace,
 	}
 
-	c, err := controller.New("tls-profile-sync", mgr, controller.Options{
+	c, err := controller.New(tlsProfileSyncCtrlName, mgr, controller.Options{
 		Reconciler: reconciler,
 	})
 	if err != nil {
@@ -124,7 +130,7 @@ func Run(ctx context.Context) error {
 		handler.TypedEnqueueRequestsFromMapFunc(
 			func(_ context.Context, cm *corev1.ConfigMap) []reconcile.Request {
 				if cm.Name == ConfigMapName && cm.Namespace == namespace {
-					return []reconcile.Request{{NamespacedName: types.NamespacedName{Name: "cluster"}}}
+					return []reconcile.Request{{NamespacedName: types.NamespacedName{Name: constants.ClusterResourceName}}}
 				}
 				return nil
 			},
@@ -148,8 +154,8 @@ type tlsProfileSyncReconciler struct {
 func (r *tlsProfileSyncReconciler) Reconcile(
 	ctx context.Context, req reconcile.Request,
 ) (reconcile.Result, error) {
-	// Only care about the "cluster" singleton
-	if req.Name != "cluster" {
+	// Only care about the cluster singleton
+	if req.Name != constants.ClusterResourceName {
 		return reconcile.Result{}, nil
 	}
 
@@ -170,7 +176,7 @@ func (r *tlsProfileSyncReconciler) Reconcile(
 
 	klog.Infof("Synced ConfigMap %s/%s: minTLSVersion=%s, profileType=%s",
 		r.namespace, ConfigMapName,
-		data["minTLSVersion"], data["profileType"])
+		data[minTLSVersionKey], data[profileTypeKey])
 
 	return reconcile.Result{}, nil
 }
@@ -240,9 +246,9 @@ func buildConfigMapData(profile *configv1.TLSSecurityProfile) map[string]string 
 	cipherSuites := libgocrypto.OpenSSLToIANACipherSuites(profileSpec.Ciphers)
 
 	return map[string]string{
-		"minTLSVersion": minTLSVersion,
-		"cipherSuites":  strings.Join(cipherSuites, ","),
-		"profileType":   profileType,
+		minTLSVersionKey: minTLSVersion,
+		cipherSuitesKey:  strings.Join(cipherSuites, ","),
+		profileTypeKey:   profileType,
 	}
 }
 

--- a/pkg/tlsprofilesync/sync_test.go
+++ b/pkg/tlsprofilesync/sync_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	configv1 "github.com/openshift/api/config/v1"
+	"github.com/stolostron/managedcluster-import-controller/pkg/constants"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -91,16 +92,16 @@ func TestBuildConfigMapData(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			data := buildConfigMapData(tt.profile)
 
-			if data["profileType"] != tt.wantProfileType {
-				t.Errorf("profileType = %q, want %q", data["profileType"], tt.wantProfileType)
+			if data[profileTypeKey] != tt.wantProfileType {
+				t.Errorf("profileType = %q, want %q", data[profileTypeKey], tt.wantProfileType)
 			}
-			if data["minTLSVersion"] != tt.wantMinVersion {
-				t.Errorf("minTLSVersion = %q, want %q", data["minTLSVersion"], tt.wantMinVersion)
+			if data[minTLSVersionKey] != tt.wantMinVersion {
+				t.Errorf("minTLSVersion = %q, want %q", data[minTLSVersionKey], tt.wantMinVersion)
 			}
-			hasCiphers := data["cipherSuites"] != ""
+			hasCiphers := data[cipherSuitesKey] != ""
 			if hasCiphers != tt.wantHasCiphers {
 				t.Errorf("hasCiphers = %v, want %v (cipherSuites=%q)",
-					hasCiphers, tt.wantHasCiphers, data["cipherSuites"])
+					hasCiphers, tt.wantHasCiphers, data[cipherSuitesKey])
 			}
 		})
 	}
@@ -111,7 +112,7 @@ func TestBuildConfigMapData_CiphersAreIANA(t *testing.T) {
 		Type: configv1.TLSProfileIntermediateType,
 	})
 
-	ciphers := data["cipherSuites"]
+	ciphers := data[cipherSuitesKey]
 	if ciphers == "" {
 		t.Fatal("expected cipher suites for Intermediate profile")
 	}
@@ -166,9 +167,9 @@ func TestSyncConfigMap_CreateAndUpdate(t *testing.T) {
 
 	// First sync should create the ConfigMap
 	data := map[string]string{
-		"minTLSVersion": "VersionTLS12",
-		"cipherSuites":  "TLS_AES_128_GCM_SHA256",
-		"profileType":   "Intermediate",
+		minTLSVersionKey: "VersionTLS12",
+		cipherSuitesKey:  "TLS_AES_128_GCM_SHA256",
+		profileTypeKey:   "Intermediate",
 	}
 	if err := reconciler.syncConfigMap(ctx, data); err != nil {
 		t.Fatalf("create failed: %v", err)
@@ -178,15 +179,15 @@ func TestSyncConfigMap_CreateAndUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get after create failed: %v", err)
 	}
-	if cm.Data["minTLSVersion"] != "VersionTLS12" {
-		t.Errorf("minTLSVersion = %q, want VersionTLS12", cm.Data["minTLSVersion"])
+	if cm.Data[minTLSVersionKey] != "VersionTLS12" {
+		t.Errorf("minTLSVersion = %q, want VersionTLS12", cm.Data[minTLSVersionKey])
 	}
 
 	// Second sync should update the ConfigMap
 	data2 := map[string]string{
-		"minTLSVersion": "VersionTLS13",
-		"cipherSuites":  "",
-		"profileType":   "Modern",
+		minTLSVersionKey: "VersionTLS13",
+		cipherSuitesKey:  "",
+		profileTypeKey:   "Modern",
 	}
 	if err := reconciler.syncConfigMap(ctx, data2); err != nil {
 		t.Fatalf("update failed: %v", err)
@@ -196,11 +197,11 @@ func TestSyncConfigMap_CreateAndUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get after update failed: %v", err)
 	}
-	if cm.Data["minTLSVersion"] != "VersionTLS13" {
-		t.Errorf("minTLSVersion = %q, want VersionTLS13", cm.Data["minTLSVersion"])
+	if cm.Data[minTLSVersionKey] != "VersionTLS13" {
+		t.Errorf("minTLSVersion = %q, want VersionTLS13", cm.Data[minTLSVersionKey])
 	}
-	if cm.Data["profileType"] != "Modern" {
-		t.Errorf("profileType = %q, want Modern", cm.Data["profileType"])
+	if cm.Data[profileTypeKey] != "Modern" {
+		t.Errorf("profileType = %q, want Modern", cm.Data[profileTypeKey])
 	}
 }
 
@@ -214,9 +215,9 @@ func TestSyncConfigMap_ExistingConfigMap(t *testing.T) {
 			Namespace: namespace,
 		},
 		Data: map[string]string{
-			"minTLSVersion": "VersionTLS12",
-			"cipherSuites":  "old-cipher",
-			"profileType":   "Intermediate",
+			minTLSVersionKey: "VersionTLS12",
+			cipherSuitesKey:  "old-cipher",
+			profileTypeKey:   "Intermediate",
 		},
 	}
 	fakeClient := fake.NewSimpleClientset(existing)
@@ -227,9 +228,9 @@ func TestSyncConfigMap_ExistingConfigMap(t *testing.T) {
 	}
 
 	data := map[string]string{
-		"minTLSVersion": "VersionTLS13",
-		"cipherSuites":  "",
-		"profileType":   "Modern",
+		minTLSVersionKey: "VersionTLS13",
+		cipherSuitesKey:  "",
+		profileTypeKey:   "Modern",
 	}
 	if err := reconciler.syncConfigMap(ctx, data); err != nil {
 		t.Fatalf("update failed: %v", err)
@@ -239,8 +240,8 @@ func TestSyncConfigMap_ExistingConfigMap(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get failed: %v", err)
 	}
-	if cm.Data["profileType"] != "Modern" {
-		t.Errorf("profileType = %q, want Modern", cm.Data["profileType"])
+	if cm.Data[profileTypeKey] != "Modern" {
+		t.Errorf("profileType = %q, want Modern", cm.Data[profileTypeKey])
 	}
 }
 
@@ -256,7 +257,7 @@ func TestReconcile_ModernProfile(t *testing.T) {
 	namespace := "test-ns"
 
 	apiServer := &configv1.APIServer{
-		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+		ObjectMeta: metav1.ObjectMeta{Name: constants.ClusterResourceName},
 		Spec: configv1.APIServerSpec{
 			TLSSecurityProfile: &configv1.TLSSecurityProfile{
 				Type: configv1.TLSProfileModernType,
@@ -272,7 +273,7 @@ func TestReconcile_ModernProfile(t *testing.T) {
 	}
 
 	result, err := r.Reconcile(ctx, reconcile.Request{
-		NamespacedName: types.NamespacedName{Name: "cluster"},
+		NamespacedName: types.NamespacedName{Name: constants.ClusterResourceName},
 	})
 	if err != nil {
 		t.Fatalf("Reconcile() error: %v", err)
@@ -286,11 +287,11 @@ func TestReconcile_ModernProfile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ConfigMap not created: %v", err)
 	}
-	if cm.Data["profileType"] != "Modern" {
-		t.Errorf("profileType = %q, want Modern", cm.Data["profileType"])
+	if cm.Data[profileTypeKey] != "Modern" {
+		t.Errorf("profileType = %q, want Modern", cm.Data[profileTypeKey])
 	}
-	if cm.Data["minTLSVersion"] != "VersionTLS13" {
-		t.Errorf("minTLSVersion = %q, want VersionTLS13", cm.Data["minTLSVersion"])
+	if cm.Data[minTLSVersionKey] != "VersionTLS13" {
+		t.Errorf("minTLSVersion = %q, want VersionTLS13", cm.Data[minTLSVersionKey])
 	}
 }
 
@@ -331,7 +332,7 @@ func TestReconcile_APIServerNotFound(t *testing.T) {
 	}
 
 	result, err := r.Reconcile(ctx, reconcile.Request{
-		NamespacedName: types.NamespacedName{Name: "cluster"},
+		NamespacedName: types.NamespacedName{Name: constants.ClusterResourceName},
 	})
 	if err != nil {
 		t.Fatalf("Reconcile() should not error on not-found: %v", err)
@@ -353,7 +354,7 @@ func TestReconcile_UpdatesExistingConfigMap(t *testing.T) {
 	namespace := "test-ns"
 
 	apiServer := &configv1.APIServer{
-		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+		ObjectMeta: metav1.ObjectMeta{Name: constants.ClusterResourceName},
 		Spec: configv1.APIServerSpec{
 			TLSSecurityProfile: &configv1.TLSSecurityProfile{
 				Type: configv1.TLSProfileModernType,
@@ -367,8 +368,8 @@ func TestReconcile_UpdatesExistingConfigMap(t *testing.T) {
 			Namespace: namespace,
 		},
 		Data: map[string]string{
-			"minTLSVersion": "VersionTLS12",
-			"profileType":   "Intermediate",
+			minTLSVersionKey: "VersionTLS12",
+			profileTypeKey:   "Intermediate",
 		},
 	}
 
@@ -380,7 +381,7 @@ func TestReconcile_UpdatesExistingConfigMap(t *testing.T) {
 	}
 
 	_, err := r.Reconcile(ctx, reconcile.Request{
-		NamespacedName: types.NamespacedName{Name: "cluster"},
+		NamespacedName: types.NamespacedName{Name: constants.ClusterResourceName},
 	})
 	if err != nil {
 		t.Fatalf("Reconcile() error: %v", err)
@@ -391,11 +392,11 @@ func TestReconcile_UpdatesExistingConfigMap(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get ConfigMap: %v", err)
 	}
-	if cm.Data["profileType"] != "Modern" {
-		t.Errorf("profileType = %q, want Modern", cm.Data["profileType"])
+	if cm.Data[profileTypeKey] != "Modern" {
+		t.Errorf("profileType = %q, want Modern", cm.Data[profileTypeKey])
 	}
-	if cm.Data["minTLSVersion"] != "VersionTLS13" {
-		t.Errorf("minTLSVersion = %q, want VersionTLS13", cm.Data["minTLSVersion"])
+	if cm.Data[minTLSVersionKey] != "VersionTLS13" {
+		t.Errorf("minTLSVersion = %q, want VersionTLS13", cm.Data[minTLSVersionKey])
 	}
 }
 

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -39,6 +39,25 @@ import (
 	"github.com/stolostron/managedcluster-import-controller/pkg/helpers/imageregistry"
 )
 
+const (
+	autoImportSecretName        = "auto-import-secret" // #nosec G101 -- resource name, not a credential
+	clusterDeploymentSecretName = "clusterdeployment-secret"
+	kubeconfigKey               = "kubeconfig"
+	tokenKey                    = "token"
+	serverKey                   = "server"
+
+	apiVersionKey                = "apiVersion"
+	kindKey                      = "kind"
+	metadataKey                  = "metadata"
+	nameKey                      = "name"
+	namespaceKey                 = "namespace"
+	specKey                      = "spec"
+	typeKey                      = "type"
+	serviceKey                   = "service"
+	servicePublishingStrategyKey = "servicePublishingStrategy"
+	routeType                    = "Route"
+)
+
 type Label struct {
 	key   string
 	value string
@@ -296,7 +315,7 @@ func InstallClusterDeployment(kubeClient kubernetes.Interface, dynamicClient dyn
 	}
 
 	clusterDeployment = clusterDeployment.DeepCopy()
-	if err := unstructured.SetNestedField(clusterDeployment.Object, true, "spec", "installed"); err != nil {
+	if err := unstructured.SetNestedField(clusterDeployment.Object, true, specKey, "installed"); err != nil {
 		return err
 	}
 
@@ -342,11 +361,11 @@ func NewAutoImportSecret(kubeClient kubernetes.Interface, clusterName string, mo
 
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "auto-import-secret",
+			Name:      autoImportSecretName,
 			Namespace: clusterName,
 		},
 		Data: map[string][]byte{
-			"kubeconfig": secret.Data["kubeconfig"],
+			kubeconfigKey: secret.Data[kubeconfigKey],
 		},
 	}, nil
 }
@@ -359,12 +378,12 @@ func NewAutoImportSecretWithToken(kubeClient kubernetes.Interface, dynamicClient
 
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "auto-import-secret",
+			Name:      autoImportSecretName,
 			Namespace: clusterName,
 		},
 		Data: map[string][]byte{
-			"token":  token,
-			"server": server,
+			tokenKey:  token,
+			serverKey: server,
 		},
 	}, nil
 }
@@ -377,15 +396,15 @@ func NewRestoreAutoImportSecret(kubeClient kubernetes.Interface, dynamicClient d
 
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "auto-import-secret",
+			Name:      autoImportSecretName,
 			Namespace: clusterName,
 			Labels: map[string]string{
-				"cluster.open-cluster-management.io/restore-auto-import-secret": "true",
+				"cluster.open-cluster-management.io/restore-auto-import-secret": constants.TrueString,
 			},
 		},
 		Data: map[string][]byte{
-			"token":  token,
-			"server": server,
+			tokenKey:  token,
+			serverKey: server,
 		},
 	}, nil
 }
@@ -398,12 +417,12 @@ func NewInvalidAutoImportSecret(kubeClient kubernetes.Interface, dynamicClient d
 
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "auto-import-secret",
+			Name:      autoImportSecretName,
 			Namespace: clusterName,
 		},
 		Data: map[string][]byte{
-			"token":  token,
-			"server": server,
+			tokenKey:  token,
+			serverKey: server,
 		},
 	}, nil
 }
@@ -422,7 +441,7 @@ func NewExternalManagedKubeconfigSecret(kubeClient kubernetes.Interface, cluster
 			Namespace: fmt.Sprintf("klusterlet-%s", clusterName),
 		},
 		Data: map[string][]byte{
-			"kubeconfig": secret.Data["kubeconfig"],
+			kubeconfigKey: secret.Data[kubeconfigKey],
 		},
 	}, nil
 }
@@ -434,7 +453,7 @@ func NewManagedClient(kubeClient kubernetes.Interface) (kubernetes.Interface, er
 		return nil, err
 	}
 
-	kubeconfigRaw, ok := secret.Data["kubeconfig"]
+	kubeconfigRaw, ok := secret.Data[kubeconfigKey]
 	if !ok {
 		return nil, fmt.Errorf("no kubeconfig data in the secret")
 	}
@@ -534,11 +553,11 @@ func newClusterDeploymentImportSecret(kubeClient kubernetes.Interface, clusterNa
 
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "clusterdeployment-secret",
+			Name:      clusterDeploymentSecretName,
 			Namespace: clusterName,
 		},
 		Data: map[string][]byte{
-			"kubeconfig": secret.Data["kubeconfig"],
+			kubeconfigKey: secret.Data[kubeconfigKey],
 		},
 	}, nil
 }
@@ -574,19 +593,19 @@ func getServerAndToken(kubeClient kubernetes.Interface, dynamicClient dynamic.In
 		return nil, nil, fmt.Errorf("failed to get apiServerURL in infrastructures cluster: %v, %v", found, err)
 	}
 
-	return []byte(apiServer), tokenSecret.Data["token"], nil
+	return []byte(apiServer), tokenSecret.Data[tokenKey], nil
 }
 
 func newCAPICluster(namespace, name string) *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": "cluster.x-k8s.io/v1beta1",
-			"kind":       "Cluster",
-			"metadata": map[string]interface{}{
-				"name":      name,
-				"namespace": namespace,
+			apiVersionKey: "cluster.x-k8s.io/v1beta1",
+			kindKey:       "Cluster",
+			metadataKey: map[string]interface{}{
+				nameKey:      name,
+				namespaceKey: namespace,
 			},
-			"spec": map[string]interface{}{},
+			specKey: map[string]interface{}{},
 		},
 	}
 }
@@ -594,13 +613,13 @@ func newCAPICluster(namespace, name string) *unstructured.Unstructured {
 func newHostedCluster(namespace, name string) *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": "hypershift.openshift.io/v1beta1",
-			"kind":       "HostedCluster",
-			"metadata": map[string]interface{}{
-				"name":      name,
-				"namespace": namespace,
+			apiVersionKey: "hypershift.openshift.io/v1beta1",
+			kindKey:       "HostedCluster",
+			metadataKey: map[string]interface{}{
+				nameKey:      name,
+				namespaceKey: namespace,
 			},
-			"spec": map[string]interface{}{
+			specKey: map[string]interface{}{
 				// 05622387-d157-4e41-8ac4-7c9708030ac0
 				// 01234567-abcd-efgh-ijkl-098765432100
 				"clusterID":                    "05622387-d157-4e41-8ac4-7c9708030ac0",
@@ -611,7 +630,7 @@ func newHostedCluster(namespace, name string) *unstructured.Unstructured {
 				"fips":    false,
 				"infraID": "hcp-" + namespace + "-" + name,
 				"platform": map[string]interface{}{
-					"type": "AWS",
+					typeKey: "AWS",
 					"aws": map[string]interface{}{
 						"cloudProviderConfig": map[string]interface{}{
 							"subnet": map[string]interface{}{
@@ -636,34 +655,34 @@ func newHostedCluster(namespace, name string) *unstructured.Unstructured {
 					"image": "quay.io/openshift-release-dev/ocp-release:4.17.2-multi",
 				},
 				"sshKey": map[string]interface{}{
-					"name": "test-ssh-key",
+					nameKey: "test-ssh-key",
 				},
 				"pullSecret": map[string]interface{}{
-					"name": "hcp-zj1-pull-secret",
+					nameKey: "hcp-zj1-pull-secret",
 				},
 				"services": []map[string]interface{}{
 					{
-						"service": "APIServer",
-						"servicePublishingStrategy": map[string]interface{}{
-							"type": "LoadBalancer",
+						serviceKey: "APIServer",
+						servicePublishingStrategyKey: map[string]interface{}{
+							typeKey: "LoadBalancer",
 						},
 					},
 					{
-						"service": "Ignition",
-						"servicePublishingStrategy": map[string]interface{}{
-							"type": "Route",
+						serviceKey: "Ignition",
+						servicePublishingStrategyKey: map[string]interface{}{
+							typeKey: routeType,
 						},
 					},
 					{
-						"service": "Konnectivity",
-						"servicePublishingStrategy": map[string]interface{}{
-							"type": "Route",
+						serviceKey: "Konnectivity",
+						servicePublishingStrategyKey: map[string]interface{}{
+							typeKey: routeType,
 						},
 					},
 					{
-						"service": "OAuthServer",
-						"servicePublishingStrategy": map[string]interface{}{
-							"type": "Route",
+						serviceKey: "OAuthServer",
+						servicePublishingStrategyKey: map[string]interface{}{
+							typeKey: routeType,
 						},
 					},
 				},
@@ -675,41 +694,41 @@ func newHostedCluster(namespace, name string) *unstructured.Unstructured {
 func newClusterdeployment(clusterName string) *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": "hive.openshift.io/v1",
-			"kind":       "ClusterDeployment",
-			"metadata": map[string]interface{}{
-				"name":      clusterName,
-				"namespace": clusterName,
+			apiVersionKey: "hive.openshift.io/v1",
+			kindKey:       "ClusterDeployment",
+			metadataKey: map[string]interface{}{
+				nameKey:      clusterName,
+				namespaceKey: clusterName,
 			},
-			"spec": map[string]interface{}{
+			specKey: map[string]interface{}{
 				"baseDomain":  "fake-domain.red-chesterfield.com",
 				"clusterName": clusterName,
 				"installed":   false,
 				"platform": map[string]interface{}{
 					"aws": map[string]interface{}{
 						"credentialsSecretRef": map[string]interface{}{
-							"name": "fake-mycluster-aws-creds",
+							nameKey: "fake-mycluster-aws-creds",
 						},
 						"region": "us-east-1",
 					},
 				},
 				"provisioning": map[string]interface{}{
 					"imageSetRef": map[string]interface{}{
-						"name": "fake-hive-clusterimageset",
+						nameKey: "fake-hive-clusterimageset",
 					},
 					"installConfigSecretRef": map[string]interface{}{
-						"name": "fake-hive-install-config",
+						nameKey: "fake-hive-install-config",
 					},
 					"sshPrivateKeySecretRef": map[string]interface{}{
-						"name": "fake-hive-ssh-private-key",
+						nameKey: "fake-hive-ssh-private-key",
 					},
 				},
 				"clusterMetadata": map[string]interface{}{
 					"adminKubeconfigSecretRef": map[string]interface{}{
-						"name": "clusterdeployment-secret",
+						nameKey: clusterDeploymentSecretName,
 					},
 					"adminPasswordSecretRef": map[string]interface{}{
-						"name": "clusterdeployment-secret",
+						nameKey: clusterDeploymentSecretName,
 					},
 					"clusterID": "my-cluster-id",
 					"infraID":   "my-infra-id",

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1456,12 +1456,12 @@ open-cluster-management.io/api/feature
 open-cluster-management.io/api/operator/v1
 open-cluster-management.io/api/work/v1
 open-cluster-management.io/api/work/v1alpha1
-# open-cluster-management.io/ocm v1.1.1-0.20260128054152-9d1a993e2c6f
+# open-cluster-management.io/ocm v1.2.1
 ## explicit; go 1.25.0
 open-cluster-management.io/ocm/deploy/cluster-manager/chart
 open-cluster-management.io/ocm/deploy/klusterlet/chart
 open-cluster-management.io/ocm/pkg/operator/helpers/chart
-# open-cluster-management.io/sdk-go v1.1.1-0.20260127092137-c07e0fafa331
+# open-cluster-management.io/sdk-go v1.2.0
 ## explicit; go 1.25.0
 open-cluster-management.io/sdk-go/pkg/cloudevents/generic/options
 open-cluster-management.io/sdk-go/pkg/cloudevents/generic/options/cert


### PR DESCRIPTION
## Summary
- Mirror of https://github.com/stolostron/managedcluster-import-controller/pull/1164 onto `backplane-2.17`
- Bump `open-cluster-management.io/ocm` to **v1.2.1**, `open-cluster-management.io/sdk-go` to **v1.2.0**, and Go builder to **1.26**
- Includes related lint-driven string constant extractions from #1164
- Conflict resolution kept `backplane-2.17` controller-runtime `v0.23.2` and the existing non-OCP gRPC LoadBalancer path (only swapped the `"grpc"` literal for `grpcAuthType`)

## Test plan
- [ ] CI unit / lint jobs pass on this PR
- [ ] Confirm go.mod shows `ocm v1.2.1` and `sdk-go v1.2.0`
- [ ] Smoke-check import-controller builds against MCE 2.17 images when available


Made with [Cursor](https://cursor.com)