### PR TITLE
ACM-30622: Wire --enable-klusterlet-network-policies to Klusterlet CRs

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -126,6 +126,8 @@ func main() {
 	_ = flightctlServer
 	pflag.StringVar(&leaderElectionNamespace, "leader-election-namespace", "", "required when the process is not running in cluster")
 	pflag.BoolVar(&helpers.DeployOnOCP, "deploy-on-ocp", true, "used to deploy the controller on OCP or not")
+	pflag.BoolVar(&helpers.EnableKlusterletNetworkPolicies, "enable-klusterlet-network-policies", false,
+		"enable NetworkPolicies feature gate on Klusterlet CRs for managed clusters")
 	pflag.Float32Var(&QPS, "kube-api-qps", 50, "QPS indicates the maximum QPS to the master from this client")
 	pflag.IntVar(&Burst, "kube-api-burst", 100, "Burst indicates the maximum burst for throttle")
 	pflag.CommandLine.SetNormalizeFunc(utilflag.WordSepNormalizeFunc)
@@ -134,6 +136,14 @@ func main() {
 
 	logs.AddFlags(pflag.CommandLine)
 	pflag.Parse()
+
+	if !pflag.CommandLine.Changed("enable-klusterlet-network-policies") {
+		if envVal, exists := os.LookupEnv("ENABLE_KLUSTERLET_NETWORK_POLICIES"); exists {
+			if val, err := strconv.ParseBool(envVal); err == nil {
+				helpers.EnableKlusterletNetworkPolicies = val
+			}
+		}
+	}
 
 	logs.InitLogs()
 	exitCode := 0

--- a/pkg/bootstrap/render.go
+++ b/pkg/bootstrap/render.go
@@ -307,6 +307,17 @@ func (c *KlusterletManifestsConfig) Generate(ctx context.Context,
 		}
 	}
 
+	// NetworkPolicies is an operator-internal feature gate (not in DefaultSpokeRegistrationFeatureGates),
+	// so it bypasses the KlusterletConfig dispatch and is set directly from the CLI flag / env var.
+	if helpers.EnableKlusterletNetworkPolicies {
+		c.chartConfig.Klusterlet.RegistrationConfiguration.FeatureGates = append(
+			c.chartConfig.Klusterlet.RegistrationConfiguration.FeatureGates,
+			operatorv1.FeatureGate{
+				Feature: "NetworkPolicies",
+				Mode:    operatorv1.FeatureGateModeTypeEnable,
+			})
+	}
+
 	// MultipleHubs
 	// Doesn't affect on the local-cluster.
 	// Using MultipleHubs can control the bootstrap kubeConfig secret/secrets easier.

--- a/pkg/bootstrap/render_test.go
+++ b/pkg/bootstrap/render_test.go
@@ -1362,19 +1362,8 @@ func TestKlusterletNetworkPoliciesFeatureGate(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			helpers.EnableKlusterletNetworkPolicies = tc.enabled
-			os.Setenv(constants.DefaultImagePullSecretEnvVarName, "test-image-pull-secret")
 
-			kubeClient := kubefake.NewSimpleClientset(
-				&corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "test-image-pull-secret",
-					},
-					Data: map[string][]byte{
-						corev1.DockerConfigJsonKey: []byte("fake-token"),
-					},
-					Type: corev1.SecretTypeDockerConfigJson,
-				},
-			)
+			kubeClient := kubefake.NewSimpleClientset()
 
 			clientHolder := &helpers.ClientHolder{
 				KubeClient: kubeClient,
@@ -1390,7 +1379,7 @@ func TestKlusterletNetworkPoliciesFeatureGate(t *testing.T) {
 				operatorv1.InstallModeDefault,
 				"test",
 				[]byte("bootstrap kubeconfig"),
-			)
+			).WithoutImagePullSecretGenerate()
 
 			manifestsBytes, _, _, err := config.Generate(context.Background(), clientHolder)
 			if err != nil {

--- a/pkg/bootstrap/render_test.go
+++ b/pkg/bootstrap/render_test.go
@@ -1338,6 +1338,91 @@ func TestKlusterletConfigGenerate(t *testing.T) {
 
 }
 
+func TestKlusterletNetworkPoliciesFeatureGate(t *testing.T) {
+	originalVal := helpers.EnableKlusterletNetworkPolicies
+	defer func() { helpers.EnableKlusterletNetworkPolicies = originalVal }()
+
+	testcases := []struct {
+		name           string
+		enabled        bool
+		expectGateSet  bool
+	}{
+		{
+			name:          "NetworkPolicies feature gate is set when enabled",
+			enabled:       true,
+			expectGateSet: true,
+		},
+		{
+			name:          "NetworkPolicies feature gate is not set when disabled",
+			enabled:       false,
+			expectGateSet: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			helpers.EnableKlusterletNetworkPolicies = tc.enabled
+			os.Setenv(constants.DefaultImagePullSecretEnvVarName, "test-image-pull-secret")
+
+			kubeClient := kubefake.NewSimpleClientset(
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-image-pull-secret",
+					},
+					Data: map[string][]byte{
+						corev1.DockerConfigJsonKey: []byte("fake-token"),
+					},
+					Type: corev1.SecretTypeDockerConfigJson,
+				},
+			)
+
+			clientHolder := &helpers.ClientHolder{
+				KubeClient: kubeClient,
+				RuntimeClient: fake.NewClientBuilder().WithScheme(testscheme).WithObjects(
+					&corev1.Namespace{
+						ObjectMeta: metav1.ObjectMeta{Name: "test"},
+					},
+				).Build(),
+				ImageRegistryClient: imageregistry.NewClient(kubeClient),
+			}
+
+			config := NewKlusterletManifestsConfig(
+				operatorv1.InstallModeDefault,
+				"test",
+				[]byte("bootstrap kubeconfig"),
+			)
+
+			manifestsBytes, _, _, err := config.Generate(context.Background(), clientHolder)
+			if err != nil {
+				t.Fatalf("Failed to generate klusterlet manifests: %v", err)
+			}
+
+			var foundGate bool
+			for _, yamlBytes := range helpers.SplitYamls(manifestsBytes) {
+				obj := helpers.MustCreateObject(yamlBytes)
+				klusterlet, ok := obj.(*operatorv1.Klusterlet)
+				if !ok {
+					continue
+				}
+				if klusterlet.Spec.RegistrationConfiguration != nil {
+					for _, fg := range klusterlet.Spec.RegistrationConfiguration.FeatureGates {
+						if fg.Feature == "NetworkPolicies" && fg.Mode == operatorv1.FeatureGateModeTypeEnable {
+							foundGate = true
+						}
+					}
+				}
+			}
+
+			if tc.expectGateSet && !foundGate {
+				t.Error("expected NetworkPolicies feature gate to be set on Klusterlet, but it was not found")
+			}
+			if !tc.expectGateSet && foundGate {
+				t.Error("expected NetworkPolicies feature gate to NOT be set on Klusterlet, but it was found")
+			}
+		})
+	}
+}
+
 func TestBuildGRPCConfigData(t *testing.T) {
 	testcases := []struct {
 		name               string

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -87,6 +87,10 @@ const (
 // DeployOnOCP is set once at the beginning
 var DeployOnOCP bool = true
 
+// EnableKlusterletNetworkPolicies controls whether the NetworkPolicies feature gate
+// is set on Klusterlet CRs created for managed clusters.
+var EnableKlusterletNetworkPolicies bool = false
+
 var (
 	genericScheme = runtime.NewScheme()
 	genericCodecs = serializer.NewCodecFactory(genericScheme)


### PR DESCRIPTION
## Summary
- Registers `--enable-klusterlet-network-policies` CLI flag (with `ENABLE_KLUSTERLET_NETWORK_POLICIES` env var fallback for hosted mode)
- When enabled, directly appends `{Feature: "NetworkPolicies", Mode: "Enable"}` to `RegistrationConfiguration.FeatureGates` on Klusterlet CRs, bypassing the KlusterletConfig dispatch since `NetworkPolicies` is an operator-internal gate (ocm#1627)
- Companion to stolostron/backplane-operator#3786

## Test plan
- [x] Unit tests pass (`TestKlusterletNetworkPoliciesFeatureGate` — enabled and disabled paths)
- [x] Existing `TestKlusterletConfigGenerate` tests pass (no regressions)
- [x] `go build ./cmd/manager/` compiles cleanly
- [x] CodeRabbit review — no actionable comments
